### PR TITLE
MCP 2025-11-25 spec coverage: typed schemas, elicitation, tool-enabled sampling, tasks, icons

### DIFF
--- a/virtual-library-mcp/database/circulation_repository.py
+++ b/virtual-library-mcp/database/circulation_repository.py
@@ -266,7 +266,11 @@ class CirculationRepository:
         if not checkout:
             raise NotFoundError(f"Checkout {return_data.checkout_id} not found")
 
-        if checkout.status != CirculationStatusEnum.ACTIVE:
+        # ACTIVE and OVERDUE loans are both returnable — OVERDUE is precisely
+        # the state where a return assesses fines. Anything else (completed,
+        # cancelled, lost) has already left circulation.
+        returnable = (CirculationStatusEnum.ACTIVE, CirculationStatusEnum.OVERDUE)
+        if checkout.status not in returnable:
             raise RepositoryException(
                 f"Return failed - checkout is not active (current status: {checkout.status})"
             )

--- a/virtual-library-mcp/icons.py
+++ b/virtual-library-mcp/icons.py
@@ -1,0 +1,44 @@
+"""Icons for MCP components (SEP-973, MCP spec 2025-11-25).
+
+The 2025-11-25 revision lets servers attach icons to tools, resources,
+resource templates, and prompts so client UIs can render them visually.
+Icons are standard ``mcp.types.Icon`` objects with a ``src`` URL.
+
+We use self-contained ``data:`` URIs (inline SVG) rather than external
+URLs: no network fetch, no tracking, works offline — the safest possible
+icon source. Clients that don't render icons simply ignore them.
+"""
+
+from urllib.parse import quote
+
+from mcp.types import Icon
+
+
+def _svg_icon(svg_body: str) -> Icon:
+    """Wrap an SVG fragment in a data-URI Icon (24x24 viewBox)."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" '
+        f'fill="none" stroke="#4A5568" stroke-width="2">{svg_body}</svg>'
+    )
+    return Icon(
+        src=f"data:image/svg+xml,{quote(svg)}",
+        mimeType="image/svg+xml",
+        sizes=["24x24"],
+    )
+
+
+BOOK_ICON = _svg_icon('<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/>')
+
+SEARCH_ICON = _svg_icon('<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>')
+
+CARD_ICON = _svg_icon('<rect x="2" y="5" width="20" height="14" rx="2"/><path d="M2 10h20"/>')
+
+STATS_ICON = _svg_icon('<path d="M3 3v18h18"/><path d="m7 13 4-4 4 4 5-6"/>')
+
+SPARKLE_ICON = _svg_icon(
+    '<path d="M12 3l1.9 5.7L19.6 10l-5.7 1.9L12 17.6l-1.9-5.7L4.4 10l5.7-1.9z"/>'
+)
+
+MAINTENANCE_ICON = _svg_icon(
+    '<path d="M14.7 6.3a5 5 0 1 0-6.6 6.6L3 18v3h3l5.1-5.1a5 5 0 0 0 6.6-6.6l-3 3-2.8-.7-.7-2.8z"/>'
+)

--- a/virtual-library-mcp/prompts/__init__.py
+++ b/virtual-library-mcp/prompts/__init__.py
@@ -1,31 +1,32 @@
 """Prompts Module - AI-Assisted Library Interactions
 
-This module demonstrates MCP prompts, which are pre-defined conversation templates
-that help LLMs interact with the library system in consistent, useful ways.
+MCP prompts are user-invoked conversation templates: unlike tools (model-
+invoked) or resources (application-driven), prompts appear in client UIs
+(slash commands, menus) for the USER to pick. Each one accepts arguments,
+pulls live library data, and returns messages that prime the LLM.
 
-MCP PROMPTS CONCEPT:
-Prompts in MCP serve as reusable interaction patterns. They:
-1. Define structured conversations between users and LLMs
-2. Accept arguments to customize the interaction
-3. Generate message sequences that guide the LLM's response
-4. Ensure consistent, high-quality AI assistance
-
-KEY FEATURES:
-- Dynamic prompt generation based on arguments
-- Integration with library data for context
-- Support for both simple and complex interactions
-- Extensible prompt system for future additions
+register() binds them with 2025-11-25 metadata (icons, tags).
 """
+
+from fastmcp import FastMCP
+
+from icons import BOOK_ICON, SPARKLE_ICON
 
 from .book_recommendations import book_recommendation_prompt
 from .reading_plan import reading_plan_prompt
 from .review_generator import review_generator_prompt
 
-# Export all prompts for server registration
-all_prompts = [
-    book_recommendation_prompt,
-    reading_plan_prompt,
-    review_generator_prompt,
-]
 
-__all__ = ["all_prompts"]
+def register(mcp: FastMCP) -> None:
+    """Register every prompt template with the server."""
+    mcp.prompt(book_recommendation_prompt, icons=[SPARKLE_ICON], tags={"ai", "patrons"})
+    mcp.prompt(reading_plan_prompt, icons=[BOOK_ICON], tags={"ai", "patrons"})
+    mcp.prompt(review_generator_prompt, icons=[SPARKLE_ICON], tags={"ai"})
+
+
+__all__ = [
+    "book_recommendation_prompt",
+    "reading_plan_prompt",
+    "register",
+    "review_generator_prompt",
+]

--- a/virtual-library-mcp/pyproject.toml
+++ b/virtual-library-mcp/pyproject.toml
@@ -23,24 +23,18 @@ classifiers = [
 # Core dependencies for MCP server functionality
 dependencies = [
     # MCP framework (v3, targets protocol revision 2025-11-25)
-    "fastmcp>=3.4,<4",
-
+    "fastmcp[tasks]>=3.4,<4",
     # Data validation and serialization - critical for MCP protocol compliance
     "pydantic>=2.13",
     "pydantic-settings>=2.10",
-
     # Database ORM for persistent data storage
     "sqlalchemy>=2.0.50",
-
     # Test data generation for realistic library data (patrons, circulation)
     "faker>=40",
-
     # Environment variable management for configuration
     "python-dotenv>=1.1",
-
     # HTTP client for external API integrations (future use)
     "httpx>=0.28",
-
     # Observability and monitoring with Pydantic Logfire
     "logfire>=4",
 ]

--- a/virtual-library-mcp/resources/__init__.py
+++ b/virtual-library-mcp/resources/__init__.py
@@ -1,25 +1,23 @@
 """Virtual Library MCP Resources Package
 
-This package contains all MCP resource implementations for the Virtual Library server.
+Resources are MCP's read-only data endpoints — the "GET" half of the
+protocol (tools are the "POST" half). Each module in this package exposes
+a declarative list of resource definitions; register() binds them to the
+server with protocol metadata from the 2025-11-25 revision (icons, tags).
 
-MCP RESOURCES EXPLAINED:
-Resources in the Model Context Protocol are read-only data endpoints that provide
-access to server-side information. Think of them as the "GET" endpoints in REST,
-but with a more structured approach:
+Resource kinds demonstrated:
+- Static resources: fixed URIs like library://books/list
+- Resource templates (RFC 6570): parameterized URIs like
+  library://books/{isbn}, which clients expand per request
 
-1. **URI-Based**: Each resource has a unique URI (e.g., library://books/list)
-2. **Read-Only**: Resources cannot modify data (use Tools for that)
-3. **Paginated**: Large collections support cursor-based pagination
-4. **Subscribable**: Clients can watch resources for changes (optional)
-5. **Metadata-Rich**: Resources include descriptions and MIME types
-
-RESOURCE VS TOOL:
-- Resource: "Show me the list of books" (read operation)
-- Tool: "Check out this book" (write operation)
-
-This separation follows the Command Query Responsibility Segregation (CQRS)
-pattern, making the protocol more predictable and secure.
+Clients are notified automatically (notifications/resources/list_changed)
+when resources are enabled or disabled at runtime — see the maintenance
+mode in tools/catalog_maintenance.py.
 """
+
+from fastmcp import FastMCP
+
+from icons import BOOK_ICON, CARD_ICON, SPARKLE_ICON, STATS_ICON
 
 from .advanced_books import advanced_book_resources
 from .books import book_resources
@@ -27,20 +25,36 @@ from .patrons import patron_resources
 from .recommendations import recommendation_resources
 from .stats import stats_resources
 
-# Combine all resources
-all_resources = (
-    book_resources
-    + advanced_book_resources
-    + patron_resources
-    + stats_resources
-    + recommendation_resources
-)
+# Resource group -> (definitions, icon, tags); one row per module.
+_RESOURCE_GROUPS = [
+    (book_resources, BOOK_ICON, {"catalog"}),
+    (advanced_book_resources, BOOK_ICON, {"catalog"}),
+    (patron_resources, CARD_ICON, {"patrons"}),
+    (stats_resources, STATS_ICON, {"stats"}),
+    (recommendation_resources, SPARKLE_ICON, {"ai"}),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register every resource and template with the server."""
+    for definitions, icon, tags in _RESOURCE_GROUPS:
+        for definition in definitions:
+            uri = definition.get("uri_template") or definition["uri"]
+            mcp.resource(
+                uri,
+                name=definition["name"],
+                description=definition["description"],
+                mime_type=definition["mime_type"],
+                icons=[icon],
+                tags=tags,
+            )(definition["handler"])
+
 
 __all__ = [
     "advanced_book_resources",
-    "all_resources",
     "book_resources",
     "patron_resources",
     "recommendation_resources",
+    "register",
     "stats_resources",
 ]

--- a/virtual-library-mcp/sampling.py
+++ b/virtual-library-mcp/sampling.py
@@ -1,255 +1,81 @@
 """
-Educational MCP Sampling Module for Virtual Library Server
+Educational MCP Sampling Module for the Virtual Library Server
 
-This module demonstrates how to use the MCP sampling feature to request
-AI-generated content from compatible clients. Sampling allows servers to
-leverage the client's LLM capabilities for dynamic content generation.
+Sampling reverses the usual MCP flow: the SERVER asks the CLIENT to run an
+LLM completion (`sampling/createMessage`). The client controls model choice,
+applies human-in-the-loop approval, and pays for tokens — the server just
+describes what it wants:
 
-Key concepts demonstrated:
-1. Client capability checking
-2. Request construction with model preferences
-3. Error handling and fallbacks
-4. Proper async/await patterns
+1. The server sends messages + model *preferences* (hints and priorities),
+   never a hard model requirement.
+2. The client may show the request to the user, pick any model, and return
+   the completion (or refuse).
+3. As of MCP 2025-11-25 (SEP-1577), sampling requests can also carry TOOLS
+   the client-side LLM may call mid-completion — see
+   tools/book_insights.py for a working example.
+
+FastMCP 3 wraps all of this in ``ctx.sample()``; this module adds the
+library's defaults, logging, and graceful degradation for clients that
+don't support sampling at all.
 """
 
 import logging
 
 from fastmcp import Context
-from mcp.types import (
-    CreateMessageRequestParams,
-    ModelHint,
-    ModelPreferences,
-    SamplingMessage,
-    TextContent,
-)
 
 from observability import logfire
 from observability.metrics import ai_generation_requests, ai_generation_tokens
 
 logger = logging.getLogger(__name__)
 
+# Model preferences are HINTS, not commands: the client maps them to the
+# closest model it actually has. Order expresses preference.
+DEFAULT_MODEL_PREFERENCES = ["claude-opus-4-8", "claude"]
+
 
 async def request_ai_generation(
-    context: Context,
+    ctx: Context,
     prompt: str,
     system_prompt: str | None = None,
     max_tokens: int = 500,
     temperature: float = 0.7,
-    intelligence_priority: float = 0.7,
-    speed_priority: float = 0.5,
+    model_preferences: list[str] | None = None,
 ) -> str | None:
-    """
-    Request AI-generated content from the MCP client using sampling.
+    """Request an LLM completion from the client, returning text or None.
 
-    This function demonstrates the complete sampling workflow:
-    1. Checking if the client supports sampling
-    2. Building a properly structured request
-    3. Handling the response
-    4. Gracefully handling errors
-
-    Args:
-        context: The FastMCP request context (provides access to session)
-        prompt: The user prompt to send to the LLM
-        system_prompt: Optional system prompt to guide the LLM's behavior
-        max_tokens: Maximum tokens to generate (default: 500)
-        temperature: Controls randomness (0.0-1.0, default: 0.7)
-        intelligence_priority: How important is model capability (0.0-1.0)
-        speed_priority: How important is fast response (0.0-1.0)
-
-    Returns:
-        The generated text if successful, None if sampling failed or unavailable
+    Returns None when the client lacks the sampling capability or the
+    request fails — callers are expected to degrade gracefully rather
+    than surface a protocol error to the user.
     """
     with logfire.span(
         "ai.sampling.request",
         ai_max_tokens=max_tokens,
         ai_temperature=temperature,
-        ai_intelligence_priority=intelligence_priority,
-        ai_speed_priority=speed_priority,
     ) as span:
-        # Step 1: Check if the client supports sampling
-        # This is crucial - not all MCP clients have LLM capabilities
-        if not context.request_context.session.client_capabilities.sampling:
-            logger.info("Client does not support sampling - returning None")
-            span.set_attribute("ai.fallback", "no_capability")
-            return None
-
         try:
-            # Record request metric
             ai_generation_requests.add(1, {"status": "requested"})
-
-            # Step 2: Build the sampling request
-            # The request includes messages, model preferences, and generation parameters
-
-            # Create the message array with the user's prompt
-            messages = [SamplingMessage(role="user", content=TextContent(type="text", text=prompt))]
-
-            # Model preferences help the client choose the right model
-            # Higher values indicate higher priority for that aspect
-            model_preferences = ModelPreferences(
-                hints=[
-                    # Prefer Claude models for this educational example
-                    ModelHint(name="claude-3-sonnet"),
-                    ModelHint(name="claude"),
-                ],
-                intelligence_priority=intelligence_priority,
-                speed_priority=speed_priority,
-                # Cost priority is inverse of the other two (bounded to avoid negative values)
-                cost_priority=max(0.0, 1.0 - (intelligence_priority + speed_priority) / 2),
-            )
-
-            # Build the complete request parameters
-            request_params = CreateMessageRequestParams(
-                messages=messages,
-                modelPreferences=model_preferences,
-                maxTokens=max_tokens,
+            result = await ctx.sample(
+                messages=prompt,
+                system_prompt=system_prompt,
+                model_preferences=model_preferences or DEFAULT_MODEL_PREFERENCES,
+                max_tokens=max_tokens,
                 temperature=temperature,
             )
-
-            # Add system prompt if provided
-            if system_prompt:
-                request_params.systemPrompt = system_prompt
-
-            # Step 3: Make the sampling request
-            # This is an async operation that goes to the client
-            logger.debug(f"Sending sampling request with prompt: {prompt[:100]}...")
-
-            result = await context.request_context.session.create_message(request_params)
-
-            # Step 4: Extract and return the generated text
-            # The result contains the AI's response in a structured format
-            if result and result.content and result.content.type == "text":
-                generated_text = result.content.text
-                logger.info(f"Successfully generated {len(generated_text)} characters")
-
-                # Track token usage
-                estimated_tokens = len(generated_text.split()) * 1.3  # Rough estimate
-                ai_generation_tokens.record(estimated_tokens)
-                span.set_attribute("ai.estimated_tokens", estimated_tokens)
-                span.set_attribute("ai.response_length", len(generated_text))
-
-                return generated_text
-            logger.warning("Sampling returned unexpected content type")
-            return None
-
         except Exception as e:
-            # Step 5: Handle errors gracefully
-            # Common errors include timeouts, user rejection, or API issues
-            logger.exception("Sampling request failed")
-            span.set_attribute("ai.error", str(e))
+            # Most commonly: the connected client never declared the
+            # sampling capability. Treat as "unavailable", not fatal.
+            logger.info("Sampling unavailable or failed: %s", e)
+            span.set_attribute("ai.fallback", "unavailable")
             ai_generation_requests.add(1, {"status": "failed"})
             return None
 
+        text = result.text
+        if not text:
+            logger.warning("Sampling returned no text content")
+            return None
 
-async def generate_book_summary(
-    context: Context,
-    book_title: str,
-    author: str,
-    genre: str,
-    year: int,
-    existing_description: str | None = None,
-) -> str | None:
-    """
-    Generate an AI-powered book summary using sampling.
-
-    This is a specific use case that shows how to:
-    - Construct domain-specific prompts
-    - Use appropriate system prompts
-    - Set model preferences for the task
-
-    Args:
-        context: The FastMCP request context
-        book_title: Title of the book
-        author: Author name
-        genre: Book genre
-        year: Publication year
-        existing_description: Optional existing description to enhance
-
-    Returns:
-        AI-generated book summary or None if generation failed
-    """
-    # Construct a detailed prompt with book information
-    prompt = f"""Generate a compelling summary for this book:
-
-Title: {book_title}
-Author: {author}
-Genre: {genre}
-Year: {year}
-{"Existing description: " + existing_description if existing_description else ""}
-
-Please create an engaging 2-3 paragraph summary that:
-- Captures the essence of the book
-- Mentions key themes without spoilers
-- Appeals to readers interested in {genre}
-- Is appropriate for a library catalog"""
-
-    # System prompt guides the AI's behavior
-    system_prompt = """You are a knowledgeable librarian creating book summaries for a library catalog.
-Your summaries should be informative, engaging, and help readers decide if they want to read the book.
-Avoid spoilers and focus on themes, writing style, and what makes the book unique."""
-
-    # For summaries, we prioritize quality over speed
-    return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
-        max_tokens=300,  # Summaries should be concise
-        temperature=0.7,  # Some creativity is good
-        intelligence_priority=0.8,  # High quality is important
-        speed_priority=0.3,  # Speed is less critical
-    )
-
-
-async def generate_reading_recommendation(
-    context: Context,
-    patron_name: str,
-    favorite_genres: list[str],
-    recent_books: list[str],
-    reading_level: str = "adult",
-) -> str | None:
-    """
-    Generate personalized reading recommendations using sampling.
-
-    This example shows how to:
-    - Use context about the user (patron)
-    - Create personalized content
-    - Balance different model priorities
-
-    Args:
-        context: The FastMCP request context
-        patron_name: Name of the library patron
-        favorite_genres: List of genres the patron enjoys
-        recent_books: List of recently read books
-        reading_level: Reading level (child/teen/adult)
-
-    Returns:
-        Personalized recommendation text or None if generation failed
-    """
-    # Build context about the patron's reading preferences
-    genres_text = ", ".join(favorite_genres)
-    recent_text = "\n- ".join(recent_books) if recent_books else "No recent reading history"
-
-    prompt = f"""Create a personalized book recommendation for a library patron:
-
-Patron: {patron_name}
-Favorite genres: {genres_text}
-Reading level: {reading_level}
-Recently read books:
-- {recent_text}
-
-Please suggest 3-5 books they might enjoy, with brief explanations of why each book would appeal to them based on their preferences."""
-
-    system_prompt = f"""You are a helpful library assistant making personalized book recommendations.
-Consider the patron's favorite genres and recent reading history.
-Make recommendations appropriate for their reading level ({reading_level}).
-Be enthusiastic and encouraging while explaining why each book is a good match."""
-
-    # Recommendations balance quality and speed
-    return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
-        max_tokens=600,  # More space for multiple recommendations
-        temperature=0.8,  # More creativity for varied recommendations
-        intelligence_priority=0.7,  # Good quality
-        speed_priority=0.6,  # Reasonably fast for interactive use
-    )
+        estimated_tokens = len(text.split()) * 1.3  # rough estimate
+        ai_generation_tokens.record(estimated_tokens)
+        span.set_attribute("ai.response_length", len(text))
+        logger.info("Sampling succeeded: %d characters generated", len(text))
+        return text

--- a/virtual-library-mcp/server.py
+++ b/virtual-library-mcp/server.py
@@ -1,217 +1,94 @@
-"""Virtual Library MCP Server - FastMCP Implementation
+"""Virtual Library MCP Server - FastMCP 3 Implementation
 
-Demonstrates a complete MCP server with resources, tools, and prompts.
-Clients connect via stdio transport for library management operations.
+A complete MCP server targeting protocol revision 2025-11-25, demonstrating:
 
-Features exposed:
-- Resources: Book catalog, patron records, library statistics
-- Tools: Checkout, return, and reservation operations
-- Prompts: Book recommendations, reading plans, review generation
+- Resources & templates: catalog browsing (library://...) with icons/tags
+- Tools: typed signatures -> rich input schemas, structured output,
+  annotations, elicitation, tool-enabled sampling, background tasks
+- Prompts: user-invoked templates for recommendations and reading plans
+- Notifications: resources/list_changed fired on visibility changes
+- Observability: Logfire middleware tracing every protocol message
+
+Transport is selected via config: stdio for local development (default).
+Streamable HTTP with OAuth 2.1 arrives with the deployment work.
 """
 
 import logging
-import signal
 import sys
-from typing import Any
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 
+import prompts
+import resources
+import tools
 from config import get_config
 from observability import LOGFIRE_AVAILABLE, initialize_observability
 from observability import get_config as get_obs_config
 from observability.middleware import MCPInstrumentationMiddleware
-from prompts import all_prompts
-from resources import all_resources
-from tools import all_tools
 
-# Load environment variables from .env file
 load_dotenv()
 
-# Initialize logging - stderr for logs, stdout for MCP protocol
+# stderr for logs — stdout belongs to the MCP protocol when using stdio.
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[logging.StreamHandler(sys.stderr)],
 )
-
 logger = logging.getLogger(__name__)
 
-# Load configuration
 config = get_config()
-
-# Initialize observability
 initialize_observability()
 
-# Create the FastMCP server instance
 mcp = FastMCP(
     name=config.server_name,
     version=config.server_version,
     instructions=(
         "Virtual Library MCP Server - A comprehensive library management system "
-        "demonstrating all MCP protocol features. Manages books, authors, patrons, "
-        "and circulation with real-time updates. Use resources to browse the catalog, "
-        "tools to perform actions, and prompts for AI-assisted recommendations."
+        "demonstrating the full MCP feature surface. Browse the catalog through "
+        "resources, perform circulation actions through tools, and use prompts "
+        "for AI-assisted recommendations. Some tools ask follow-up questions "
+        "(elicitation) or generate content via your LLM (sampling)."
     ),
 )
 
-# Add observability middleware if enabled
+# Observability middleware traces every MCP message when Logfire is available.
 obs_config = get_obs_config()
 if obs_config.enabled and LOGFIRE_AVAILABLE:
     logger.info("Enabling observability middleware for MCP protocol tracing")
     mcp.add_middleware(MCPInstrumentationMiddleware())
-elif not obs_config.enabled:
-    logger.debug("Observability middleware disabled via configuration")
-elif not LOGFIRE_AVAILABLE:
-    logger.debug("Observability middleware unavailable (Logfire not installed)")
 
-# Register all resources with the MCP server
-
-for resource in all_resources:
-    uri = resource.get("uri_template", resource.get("uri"))
-    if not uri:
-        logger.error("Resource missing URI: %s", resource)
-        continue
-
-    logger.debug("Registering resource: %s with URI: %s", resource["name"], uri)
-    try:
-        mcp.resource(
-            uri=uri,
-            name=resource["name"],
-            description=resource["description"],
-            mime_type=resource["mime_type"],
-        )(resource["handler"])
-    except Exception:
-        logger.exception("Failed to register resource %s", resource["name"])
-        raise
-
-logger.info("Registered %d resources", len(all_resources))
-
-# Register all tools with the MCP server
-for tool_def in all_tools:
-    logger.debug("Registering tool: %s", tool_def["name"])
-    try:
-        # FastMCP requires the handler to be decorated directly
-        # We'll use the add_tool method with Tool.from_function
-        from fastmcp.tools import Tool
-
-        tool_instance = Tool.from_function(
-            fn=tool_def["handler"],
-            name=tool_def["name"],
-            description=tool_def["description"],
-        )
-        mcp.add_tool(tool_instance)
-    except Exception:
-        logger.exception("Failed to register tool %s", tool_def["name"])
-        raise
-
-logger.info("Registered %d tools", len(all_tools))
-
-# Register all prompts with the MCP server
-# FastMCP expects prompts to be decorated functions
-for prompt_fn in all_prompts:
-    logger.debug("Registering prompt: %s", prompt_fn.__name__)
-    try:
-        # Use the prompt decorator to register the function
-        mcp.prompt()(prompt_fn)
-    except Exception:
-        logger.exception("Failed to register prompt %s", prompt_fn.__name__)
-        raise
-
-logger.info("Registered %d prompts", len(all_prompts))
-
-
-async def handle_initialization(params: dict[str, Any]) -> None:
-    """Handle MCP client initialization.
-
-    Logs client info and capabilities for debugging.
-    Client sends 'initialize', server responds with capabilities.
-    """
-    client_info = params.get("clientInfo", {})
-    client_capabilities = params.get("capabilities", {})
-    protocol_version = params.get("protocolVersion", "unknown")
-
-    logger.info(
-        "MCP Client connecting: %s v%s (Protocol: %s)",
-        client_info.get("name", "Unknown"),
-        client_info.get("version", "Unknown"),
-        protocol_version,
-    )
-
-    if client_capabilities:
-        logger.debug("Client capabilities: %s", client_capabilities)
-
-
-async def handle_shutdown() -> None:
-    """Handle graceful server shutdown.
-
-    Logs shutdown and cleans up resources.
-    """
-    logger.info("MCP Server shutting down gracefully...")
-    logger.info("Shutdown complete")
-
-
-async def handle_error(error: Exception) -> None:
-    """Handle server-level errors.
-
-    Logs errors for debugging. MCP uses standard JSON-RPC error codes.
-    """
-    logger.error("MCP Server error: %s: %s", type(error).__name__, error)
-
-
-def run_stdio_server() -> None:
-    """Run the MCP server using stdio transport.
-
-    Stdin receives JSON-RPC requests, stdout sends responses.
-    Ideal for local development and subprocess architectures.
-    """
-    logger.info("Starting %s v%s on stdio transport", config.server_name, config.server_version)
-
-    if config.debug:
-        logging.getLogger().setLevel(logging.DEBUG)
-        logger.debug("Debug mode enabled - verbose protocol logging active")
-    else:
-        logging.getLogger("fastmcp").setLevel(logging.WARNING)
-
-    # Set up signal handlers for graceful shutdown
-    def signal_handler(signum: int, _frame: Any) -> None:
-        logger.info("Received signal %s, initiating shutdown...", signum)
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
-    try:
-        logger.info("MCP Server ready and waiting for connections...")
-        mcp.run(transport="stdio")
-    except Exception:
-        logger.exception("Fatal error in MCP server")
-        sys.exit(1)
+# Each package registers its own components (see <package>/__init__.py).
+resources.register(mcp)
+tools.register(mcp)
+prompts.register(mcp)
 
 
 def main() -> None:
-    """Main entry point for the MCP server.
+    """Entry point: run the server on the configured transport."""
+    logger.info(
+        "%s v%s starting (transport=%s, debug=%s)",
+        config.server_name,
+        config.server_version,
+        config.transport,
+        config.debug,
+    )
 
-    Starts the server via command line or entry point.
-    """
+    if config.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger("fastmcp").setLevel(logging.WARNING)
+
     try:
-        logger.info("=" * 60)
-        logger.info("Virtual Library MCP Server")
-        logger.info("Version: %s", config.server_version)
-        logger.info("Transport: %s", config.transport)
-        logger.info("Debug Mode: %s", config.debug)
-        logger.info("=" * 60)
-
         if config.transport == "stdio":
-            run_stdio_server()
+            mcp.run(transport="stdio")
         else:
             logger.error("Unsupported transport: %s", config.transport)
             sys.exit(1)
-
     except KeyboardInterrupt:
         logger.info("Server stopped by user")
     except Exception:
-        logger.exception("Failed to start MCP server")
+        logger.exception("Fatal error in MCP server")
         sys.exit(1)
 
 

--- a/virtual-library-mcp/tests/test_sampling.py
+++ b/virtual-library-mcp/tests/test_sampling.py
@@ -1,201 +1,78 @@
-"""
-Direct tests for the sampling module - Educational Testing Example
+"""Unit tests for the sampling helper module.
 
-These tests demonstrate how to test MCP sampling functionality
-without complex database dependencies.
+request_ai_generation is a thin layer over ctx.sample(); these tests use a
+duck-typed context stub so they need neither a database nor a client.
+The full protocol round-trip is covered in tests/tools/test_book_insights.py.
 """
-
-from unittest.mock import AsyncMock, Mock
 
 import pytest
-from mcp.types import CreateMessageResult, TextContent
 
-from sampling import generate_book_summary, generate_reading_recommendation, request_ai_generation
-
-
-@pytest.fixture
-def mock_context_with_sampling():
-    """Create a mock context with sampling capability enabled."""
-    context = Mock()
-    context.request_context.session.client_capabilities.sampling = True
-    return context
+from sampling import DEFAULT_MODEL_PREFERENCES, request_ai_generation
 
 
-@pytest.fixture
-def mock_context_without_sampling():
-    """Create a mock context with sampling capability disabled."""
-    context = Mock()
-    context.request_context.session.client_capabilities.sampling = False
-    return context
+class _SampleResult:
+    def __init__(self, text):
+        self.text = text
 
 
-@pytest.mark.asyncio
-async def test_request_ai_generation_success(mock_context_with_sampling):
-    """Test successful AI generation request."""
-    # Mock the sampling response
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(type="text", text="This is the generated AI response."),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
+class _StubContext:
+    """Just enough of fastmcp.Context for request_ai_generation."""
 
-    # Mock the create_message method
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        return_value=mock_response
-    )
+    def __init__(self, text="generated text", error: Exception | None = None):
+        self._text = text
+        self._error = error
+        self.calls: list[dict] = []
 
-    # Act
-    result = await request_ai_generation(
-        context=mock_context_with_sampling,
-        prompt="Generate something interesting",
-        system_prompt="You are a helpful assistant",
-        max_tokens=100,
-        temperature=0.7,
-    )
-
-    # Assert
-    assert result == "This is the generated AI response."
-    mock_context_with_sampling.request_context.session.create_message.assert_called_once()
-
-    # Verify request parameters
-    call_args = mock_context_with_sampling.request_context.session.create_message.call_args[0][0]
-    assert len(call_args.messages) == 1
-    assert call_args.messages[0].role == "user"
-    assert call_args.messages[0].content.text == "Generate something interesting"
-    assert call_args.systemPrompt == "You are a helpful assistant"
-    assert call_args.maxTokens == 100
-    assert call_args.temperature == 0.7
+    async def sample(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._error:
+            raise self._error
+        return _SampleResult(self._text)
 
 
-@pytest.mark.asyncio
-async def test_request_ai_generation_no_sampling_capability(mock_context_without_sampling):
-    """Test behavior when client doesn't support sampling."""
-    # Act
-    result = await request_ai_generation(
-        context=mock_context_without_sampling,
-        prompt="Generate something",
-    )
+class TestRequestAiGeneration:
+    async def test_returns_generated_text(self):
+        ctx = _StubContext(text="Here is your summary.")
+        result = await request_ai_generation(ctx, "Summarize this book")
+        assert result == "Here is your summary."
 
-    # Assert
-    assert result is None
+    async def test_passes_through_parameters(self):
+        ctx = _StubContext()
+        await request_ai_generation(
+            ctx,
+            "prompt",
+            system_prompt="be a librarian",
+            max_tokens=123,
+            temperature=0.2,
+        )
+        call = ctx.calls[0]
+        assert call["messages"] == "prompt"
+        assert call["system_prompt"] == "be a librarian"
+        assert call["max_tokens"] == 123
+        assert call["temperature"] == 0.2
 
+    async def test_default_model_preferences_applied(self):
+        ctx = _StubContext()
+        await request_ai_generation(ctx, "prompt")
+        assert ctx.calls[0]["model_preferences"] == DEFAULT_MODEL_PREFERENCES
 
-@pytest.mark.asyncio
-async def test_request_ai_generation_failure(mock_context_with_sampling):
-    """Test handling of sampling failures."""
-    # Mock a sampling failure
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        side_effect=Exception("Sampling failed: User rejected")
-    )
+    async def test_custom_model_preferences_override_default(self):
+        ctx = _StubContext()
+        await request_ai_generation(ctx, "prompt", model_preferences=["gpt-x"])
+        assert ctx.calls[0]["model_preferences"] == ["gpt-x"]
 
-    # Act
-    result = await request_ai_generation(
-        context=mock_context_with_sampling,
-        prompt="Generate something",
-    )
+    async def test_failure_returns_none_not_exception(self):
+        ctx = _StubContext(error=RuntimeError("client lacks sampling capability"))
+        result = await request_ai_generation(ctx, "prompt")
+        assert result is None
 
-    # Assert
-    assert result is None
+    async def test_empty_response_returns_none(self):
+        ctx = _StubContext(text="")
+        result = await request_ai_generation(ctx, "prompt")
+        assert result is None
 
-
-@pytest.mark.asyncio
-async def test_generate_book_summary(mock_context_with_sampling):
-    """Test the book summary generation helper."""
-    # Mock response
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(type="text", text="A compelling tale of adventure and discovery..."),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        return_value=mock_response
-    )
-
-    # Act
-    result = await generate_book_summary(
-        context=mock_context_with_sampling,
-        book_title="The Adventure",
-        author="Jane Doe",
-        genre="Fiction",
-        year=2023,
-    )
-
-    # Assert
-    assert result == "A compelling tale of adventure and discovery..."
-
-    # Verify the prompt includes book details
-    call_args = mock_context_with_sampling.request_context.session.create_message.call_args[0][0]
-    prompt_text = call_args.messages[0].content.text
-    assert "The Adventure" in prompt_text
-    assert "Jane Doe" in prompt_text
-    assert "Fiction" in prompt_text
-    assert "2023" in prompt_text
-
-
-@pytest.mark.asyncio
-async def test_generate_reading_recommendation(mock_context_with_sampling):
-    """Test the reading recommendation generation helper."""
-    # Mock response
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(
-            type="text", text="Based on your love of mystery novels, I recommend..."
-        ),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        return_value=mock_response
-    )
-
-    # Act
-    result = await generate_reading_recommendation(
-        context=mock_context_with_sampling,
-        patron_name="John Smith",
-        favorite_genres=["Mystery", "Thriller"],
-        recent_books=["Gone Girl", "The Silent Patient"],
-        reading_level="adult",
-    )
-
-    # Assert
-    assert "Based on your love of mystery novels" in result
-
-    # Verify the prompt includes patron details
-    call_args = mock_context_with_sampling.request_context.session.create_message.call_args[0][0]
-    prompt_text = call_args.messages[0].content.text
-    assert "John Smith" in prompt_text
-    assert "Mystery, Thriller" in prompt_text
-    assert "Gone Girl" in prompt_text
-
-
-@pytest.mark.asyncio
-async def test_model_preferences():
-    """Test that model preferences are set correctly."""
-    context = Mock()
-    context.request_context.session.client_capabilities.sampling = True
-
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(type="text", text="Response"),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    context.request_context.session.create_message = AsyncMock(return_value=mock_response)
-
-    # Act with custom priorities
-    await request_ai_generation(
-        context=context, prompt="Test", intelligence_priority=0.9, speed_priority=0.2
-    )
-
-    # Assert model preferences
-    call_args = context.request_context.session.create_message.call_args[0][0]
-    prefs = call_args.modelPreferences
-    assert prefs.intelligence_priority == 0.9
-    assert prefs.speed_priority == 0.2
-    # Cost priority should be calculated
-    assert prefs.cost_priority == 1.0 - (0.9 + 0.2) / 2
+    @pytest.mark.parametrize("max_tokens", [1, 500, 4000])
+    async def test_token_limits_forwarded(self, max_tokens):
+        ctx = _StubContext()
+        await request_ai_generation(ctx, "prompt", max_tokens=max_tokens)
+        assert ctx.calls[0]["max_tokens"] == max_tokens

--- a/virtual-library-mcp/tests/tools/conftest.py
+++ b/virtual-library-mcp/tests/tools/conftest.py
@@ -1,0 +1,139 @@
+"""Shared fixtures for tool tests.
+
+Tool tests run through the FastMCP in-memory Client against the real
+server instance (server.mcp), so they exercise the actual protocol path:
+input schema validation, elicitation round-trips, structured content,
+and ToolError -> isError conversion. The only thing faked is the
+database session, which is pointed at a seeded per-test SQLite database.
+"""
+
+from contextlib import contextmanager
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from database.schema import (
+    Author as AuthorDB,
+)
+from database.schema import (
+    Book as BookDB,
+)
+from database.schema import (
+    CheckoutRecord as CheckoutDB,
+)
+from database.schema import (
+    CirculationStatusEnum,
+)
+from database.schema import (
+    Patron as PatronDB,
+)
+
+# Every tools module imports its session factory into its own namespace,
+# so each must be patched where it is *used*, not where it is defined.
+_SESSION_FACTORY_PATCHES = [
+    "tools.search.get_session",
+    "tools.circulation.get_session",
+    "tools.membership.get_session",
+    "tools.bulk_import.session_scope",
+    "tools.catalog_maintenance.session_scope",
+    "tools.book_insights.session_scope",
+]
+
+
+@pytest.fixture
+def library(test_db_session, monkeypatch):
+    """A small seeded library wired into every tool module.
+
+    Contents:
+    - author_test001 with two books (one available, one with 0 copies)
+    - patron_clean001: active, no fines
+    - patron_fines001: active, $4.50 outstanding fines (elicitation trigger)
+    - patron_lapsed01: expired membership
+    - checkout_active01: open loan for patron_clean001 (overdue by 4 days)
+    """
+
+    @contextmanager
+    def _test_session():
+        yield test_db_session
+
+    for target in _SESSION_FACTORY_PATCHES:
+        monkeypatch.setattr(target, _test_session)
+
+    author = AuthorDB(id="author_test001", name="Test Author", birth_date=date(1970, 1, 1))
+    test_db_session.add(author)
+
+    available_book = BookDB(
+        isbn="9780134685991",
+        title="The Available Book",
+        author_id="author_test001",
+        genre="Fiction",
+        publication_year=2020,
+        available_copies=3,
+        total_copies=3,
+        description="A book with copies on the shelf.",
+    )
+    unavailable_book = BookDB(
+        isbn="9780134685007",
+        title="The Popular Book",
+        author_id="author_test001",
+        genre="Science Fiction",
+        publication_year=2021,
+        available_copies=0,
+        total_copies=2,
+        description="A book that is always checked out.",
+    )
+    test_db_session.add_all([available_book, unavailable_book])
+
+    today = date.today()
+    patrons = [
+        PatronDB(
+            id="patron_clean001",
+            name="Clean Reader",
+            email="clean@example.com",
+            membership_date=today - timedelta(days=400),
+            expiration_date=today + timedelta(days=200),
+            status="active",
+            borrowing_limit=5,
+            current_checkouts=1,
+            total_checkouts=12,
+            outstanding_fines=0.0,
+        ),
+        PatronDB(
+            id="patron_fines001",
+            name="Fined Reader",
+            email="fined@example.com",
+            membership_date=today - timedelta(days=300),
+            expiration_date=today + timedelta(days=100),
+            status="active",
+            borrowing_limit=5,
+            current_checkouts=0,
+            total_checkouts=30,
+            outstanding_fines=4.50,
+        ),
+        PatronDB(
+            id="patron_lapsed01",
+            name="Lapsed Reader",
+            email="lapsed@example.com",
+            membership_date=today - timedelta(days=900),
+            expiration_date=today - timedelta(days=90),
+            status="expired",
+            borrowing_limit=5,
+            current_checkouts=0,
+            total_checkouts=4,
+            outstanding_fines=0.0,
+        ),
+    ]
+    test_db_session.add_all(patrons)
+
+    checkout = CheckoutDB(
+        id="checkout_active01",
+        patron_id="patron_clean001",
+        book_isbn="9780134685007",
+        checkout_date=datetime.now() - timedelta(days=18),
+        due_date=today - timedelta(days=4),
+        status=CirculationStatusEnum.OVERDUE,
+    )
+    test_db_session.add(checkout)
+    test_db_session.commit()
+
+    return test_db_session

--- a/virtual-library-mcp/tests/tools/test_book_insights.py
+++ b/virtual-library-mcp/tests/tools/test_book_insights.py
@@ -1,317 +1,121 @@
-"""
-Tests for the Book Insights Tool - Demonstrating Sampling Testing Patterns
+"""Tests for book insights — sampling, tool-enabled sampling, and fallback.
 
-This test file shows how to properly test MCP sampling functionality:
-1. Mocking sampling responses
-2. Testing both success and failure cases
-3. Verifying fallback behavior
-4. Testing different insight types
+The in-memory client either provides a sampling_handler (simulating a
+client whose LLM answers the server's request) or omits it (simulating a
+client without the sampling capability, which must trigger fallback).
 """
-
-from contextlib import contextmanager
-from datetime import date
-from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from mcp.types import CreateMessageResult, TextContent
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
-from database.schema import Author
-from database.schema import Book as BookDB
-from models.book import Book
-from tools.book_insights import InsightType, generate_book_insights_handler
-
-
-@pytest.fixture
-def mock_author():
-    """Create a mock author for testing."""
-    return Author(
-        id="author_fitzgerald01",
-        name="F. Scott Fitzgerald",
-        birth_date=date(1896, 9, 24),
-        nationality="American",
-        biography="American novelist and short story writer",
-    )
+import server
+from tools.book_insights import search_library_catalog
 
 
 @pytest.fixture
-def mock_book_db(mock_author):
-    """Create a mock database book for testing."""
-    book = BookDB(
-        isbn="9780134110362",
-        title="The Pragmatic Programmer",
-        author_id="author_fitzgerald01",
-        genre="Technology",
-        publication_year=1999,
-        description="A classic book on software development best practices",
-        available_copies=3,
-        total_copies=5,
-    )
-    # Set the author relationship
-    book.author = mock_author
-    return book
+def sampling_calls():
+    return []
 
 
 @pytest.fixture
-def mock_context_with_sampling():
-    """Create a mock context with sampling capability enabled."""
-    context = Mock()
-    context.request_context.session.client_capabilities.sampling = True
-    return context
+async def sampling_client(library, sampling_calls):
+    """Client that 'runs' sampling requests with a canned response."""
+
+    async def handler(messages, params, context):
+        sampling_calls.append(params)
+        return "A thoughtful AI-generated analysis of the book."
+
+    async with Client(server.mcp, sampling_handler=handler) as c:
+        yield c
 
 
 @pytest.fixture
-def mock_context_without_sampling():
-    """Create a mock context with sampling capability disabled."""
-    context = Mock()
-    context.request_context.session.client_capabilities.sampling = False
-    return context
+async def plain_client(library):
+    """Client WITHOUT sampling support."""
+    async with Client(server.mcp) as c:
+        yield c
 
 
-@pytest.fixture
-def mock_book_model(mock_book_db):
-    """Create a Book model from the database object."""
-    return Book(
-        isbn=mock_book_db.isbn,
-        title=mock_book_db.title,
-        author_id=mock_book_db.author_id,
-        author_name=mock_book_db.author.name,
-        genre=mock_book_db.genre,
-        publication_year=mock_book_db.publication_year,
-        description=mock_book_db.description,
-        available_copies=mock_book_db.available_copies,
-        total_copies=mock_book_db.total_copies,
-    )
-
-
-@contextmanager
-def mock_repositories(book_model, author_name="F. Scott Fitzgerald"):
-    """Helper to mock both book and author repositories."""
-    with (
-        patch("tools.book_insights.BookRepository") as MockBookRepo,
-        patch("tools.book_insights.AuthorRepository") as MockAuthorRepo,
-    ):
-        # Mock book repository
-        mock_book_repo = Mock()
-        mock_book_repo.get_by_isbn.return_value = book_model
-        MockBookRepo.return_value = mock_book_repo
-
-        # Mock author repository
-        mock_author_repo = Mock()
-        mock_author = Mock()
-        mock_author.name = author_name
-        mock_author_repo.get_by_id.return_value = mock_author
-        MockAuthorRepo.return_value = mock_author_repo
-
-        yield mock_book_repo, mock_author_repo
-
-
-@pytest.mark.asyncio
-async def test_generate_book_insights_with_sampling_summary(
-    mock_context_with_sampling, mock_book_model
-):
-    """Test generating a book summary using sampling."""
-
-    # Mock the sampling response
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(
-            type="text",
-            text="This seminal work by Andrew Hunt and David Thomas revolutionizes how developers approach their craft. Through practical wisdom and timeless principles, the authors guide readers toward becoming more effective programmers. The book covers essential topics from personal responsibility to architectural decisions, making it invaluable for developers at any stage of their career.",
-        ),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    # Mock the create_message method
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        return_value=mock_response
-    )
-
-    # Act: Generate insights with mocked repositories
-    with mock_repositories(mock_book_model):
-        result = await generate_book_insights_handler(
-            context=mock_context_with_sampling, isbn="9780134110362", insight_type="summary"
+class TestSamplingPath:
+    async def test_summary_uses_client_llm(self, sampling_client, sampling_calls):
+        result = await sampling_client.call_tool(
+            "generate_book_insights",
+            {"isbn": "9780134685991", "insight_type": "summary"},
         )
+        text = result.content[0].text
+        assert "AI-Generated Summary" in text
+        assert "thoughtful AI-generated analysis" in text
+        assert len(sampling_calls) == 1
 
-    # Assert: Check the result
-    assert "AI-Generated Summary" in result
-    assert "The Pragmatic Programmer" in result
-    assert "seminal work" in result
-    assert "Andrew Hunt and David Thomas" in result
-
-    # Verify the sampling method was called
-    mock_context_with_sampling.request_context.session.create_message.assert_called_once()
-
-    # Verify the request parameters
-    call_args = mock_context_with_sampling.request_context.session.create_message.call_args[0][0]
-    assert len(call_args.messages) == 1
-    assert call_args.messages[0].role == "user"
-    assert "The Pragmatic Programmer" in call_args.messages[0].content.text
-    assert call_args.maxTokens == 400
-
-
-@pytest.mark.asyncio
-async def test_generate_book_insights_without_sampling(
-    mock_context_without_sampling, mock_book_model
-):
-    """Test fallback behavior when sampling is not available."""
-    # Act: Generate insights without sampling
-    with mock_repositories(mock_book_model):
-        result = await generate_book_insights_handler(
-            context=mock_context_without_sampling, isbn="9780134110362", insight_type="summary"
+    async def test_model_preferences_are_hints(self, sampling_client, sampling_calls):
+        await sampling_client.call_tool(
+            "generate_book_insights",
+            {"isbn": "9780134685991", "insight_type": "themes"},
         )
+        prefs = sampling_calls[0].modelPreferences
+        assert prefs is not None
+        assert prefs.hints[0].name == "claude-opus-4-8"
 
-    # Assert: Check fallback response
-    assert "Book Information" in result
-    assert "The Pragmatic Programmer" in result
-    assert "Technology" in result
-    assert "A classic book on software development best practices" in result
-    assert (
-        "AI-generated summaries require a client with sampling support" not in result
-    )  # Has description
+    async def test_unknown_isbn_is_tool_error(self, sampling_client):
+        with pytest.raises(ToolError, match="not found"):
+            await sampling_client.call_tool("generate_book_insights", {"isbn": "9990000000000"})
 
 
-@pytest.mark.asyncio
-async def test_generate_book_insights_themes(mock_context_with_sampling, mock_book_model):
-    """Test generating theme analysis using sampling."""
-
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(
-            type="text",
-            text="""1. **Craftsmanship and Professionalism**: The book emphasizes treating programming as a craft, encouraging developers to take pride in their work and continuously improve their skills.
-
-2. **Pragmatic Problem Solving**: Focus on practical solutions rather than theoretical perfection, choosing the right tool for the job.
-
-3. **Continuous Learning**: The importance of staying current with technology while understanding timeless principles.
-
-4. **Communication and Teamwork**: How effective communication is as important as technical skills in software development.
-
-5. **Software Entropy**: The concept of technical debt and how to prevent code decay through refactoring and maintenance.""",
-        ),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        return_value=mock_response
-    )
-
-    # Act
-    with mock_repositories(mock_book_model):
-        result = await generate_book_insights_handler(
-            context=mock_context_with_sampling, isbn="9780134110362", insight_type="themes"
+class TestFallbackPath:
+    async def test_summary_falls_back_without_sampling(self, plain_client):
+        result = await plain_client.call_tool(
+            "generate_book_insights",
+            {"isbn": "9780134685991", "insight_type": "summary"},
         )
+        text = result.content[0].text
+        assert "Book Information" in text
+        assert "The Available Book" in text
 
-    # Assert
-    assert "AI-Generated Themes" in result
-    assert "Craftsmanship and Professionalism" in result
-    assert "Software Entropy" in result
-
-
-@pytest.mark.asyncio
-async def test_generate_book_insights_sampling_failure(mock_context_with_sampling, mock_book_model):
-    """Test handling of sampling failures."""
-
-    # Mock a sampling failure
-    mock_context_with_sampling.request_context.session.create_message = AsyncMock(
-        side_effect=Exception("Sampling request failed: User rejected")
-    )
-
-    # Act
-    with mock_repositories(mock_book_model):
-        result = await generate_book_insights_handler(
-            context=mock_context_with_sampling, isbn="9780134110362", insight_type="summary"
-        )
-
-    # Assert: Should fall back gracefully
-    assert "Book Information" in result
-    assert "The Pragmatic Programmer" in result
-    # Should show the existing description since sampling failed
-    assert "A classic book on software development best practices" in result
+    async def test_each_insight_type_has_meaningful_fallback(self, plain_client):
+        for insight_type in ("themes", "discussion_questions", "similar_books"):
+            result = await plain_client.call_tool(
+                "generate_book_insights",
+                {"isbn": "9780134685991", "insight_type": insight_type},
+            )
+            assert "sampling support" in result.content[0].text
 
 
-@pytest.mark.asyncio
-async def test_generate_book_insights_invalid_isbn(mock_context_with_sampling):
-    """Test handling of invalid ISBN."""
-    # Act
-    with mock_repositories(None):  # Return None for invalid ISBN
-        result = await generate_book_insights_handler(
-            context=mock_context_with_sampling, isbn="invalid-isbn", insight_type="summary"
-        )
+class TestToolEnabledSampling:
+    """SEP-1577: the similar_books insight hands the client's LLM a tool."""
 
-    # Assert
-    assert "Error: Book with ISBN invalid-isbn not found" in result
+    async def test_similar_books_offers_catalog_tool(self, library):
+        from mcp.types import SamplingCapability, SamplingToolsCapability
 
+        seen_tools: list = []
 
-@pytest.mark.asyncio
-async def test_all_insight_types(mock_context_without_sampling, mock_book_model):
-    """Test all insight types work with fallback responses."""
+        async def handler(messages, params, context):
+            seen_tools.extend(getattr(params, "tools", None) or [])
+            return "Grounded recommendations citing real holdings."
 
-    insight_types: list[InsightType] = [
-        "summary",
-        "themes",
-        "discussion_questions",
-        "similar_books",
-    ]
-
-    for insight_type in insight_types:
-        # Act
-        with mock_repositories(mock_book_model):
-            result = await generate_book_insights_handler(
-                context=mock_context_without_sampling,
-                isbn="9780134110362",
-                insight_type=insight_type,
+        async with Client(
+            server.mcp,
+            sampling_handler=handler,
+            # SEP-1577: the client must advertise sampling.tools support,
+            # otherwise the server refuses to send tools with the request.
+            sampling_capabilities=SamplingCapability(tools=SamplingToolsCapability()),
+        ) as client:
+            result = await client.call_tool(
+                "generate_book_insights",
+                {"isbn": "9780134685991", "insight_type": "similar_books"},
             )
 
-        # Assert
-        assert "Book Information" in result
-        assert "The Pragmatic Programmer" in result
+        assert "Grounded recommendations" in result.content[0].text
+        assert any(t.name == "search_library_catalog" for t in seen_tools)
 
-        # Check specific content for each type
-        if insight_type == "themes":
-            assert "Genre-Typical Themes" in result
-        elif insight_type == "discussion_questions":
-            assert "Generic Discussion Questions" in result
-        elif insight_type == "similar_books":
-            assert "Finding Similar Books" in result
-
-
-@pytest.mark.asyncio
-async def test_sampling_request_parameters(mock_context_with_sampling, mock_book_model):
-    """Test that sampling requests use appropriate parameters for different insight types."""
-
-    mock_response = CreateMessageResult(
-        role="assistant",
-        content=TextContent(type="text", text="Mock response"),
-        model="claude-3-sonnet",
-        stop_reason="end_turn",
-    )
-
-    mock_create_message = AsyncMock(return_value=mock_response)
-    mock_context_with_sampling.request_context.session.create_message = mock_create_message
-
-    # Test different insight types and their parameters
-    test_cases = [
-        ("summary", 400, 0.7, 0.8, 0.4),
-        ("themes", 500, 0.6, 0.9, 0.3),
-        ("discussion_questions", 600, 0.8, 0.7, 0.5),
-        ("similar_books", 700, 0.8, 0.7, 0.6),
-    ]
-
-    for insight_type, expected_tokens, expected_temp, expected_intel, expected_speed in test_cases:
-        # Reset mock
-        mock_create_message.reset_mock()
-
-        # Act
-        with mock_repositories(mock_book_model):
-            await generate_book_insights_handler(
-                context=mock_context_with_sampling, isbn="9780134110362", insight_type=insight_type
-            )
-
-        # Assert
-        call_args = mock_create_message.call_args[0][0]
-        assert call_args.maxTokens == expected_tokens
-        assert call_args.temperature == expected_temp
-        assert call_args.modelPreferences.intelligence_priority == expected_intel
-        assert call_args.modelPreferences.speed_priority == expected_speed
+    def test_catalog_search_tool_returns_real_holdings(self, library):
+        rows = search_library_catalog("Science Fiction")
+        assert rows == [
+            {
+                "title": "The Popular Book",
+                "isbn": "9780134685007",
+                "genre": "Science Fiction",
+                "year": 2021,
+                "available": False,
+            }
+        ]

--- a/virtual-library-mcp/tests/tools/test_bulk_import.py
+++ b/virtual-library-mcp/tests/tools/test_bulk_import.py
@@ -1,365 +1,134 @@
-"""Tests for bulk import tool with progress notifications."""
+"""Tests for bulk import: path confinement, parsing, and progress.
 
+The path-confinement tests are security tests: a remote MCP client must
+never be able to point this tool at an arbitrary server path.
+"""
+
+import csv
 import json
-import time
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastmcp import Context
-from pydantic import ValidationError
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
-from tools.bulk_import import (
-    BulkImportInput,
-    bulk_import_books_handler,
-    import_books_from_file,
-)
+import server
+import tools.bulk_import as bulk_import_module
+from database.schema import Book as BookDB
 
 
-class TestBulkImportInput:
-    """Test input validation for bulk import tool."""
-
-    def test_valid_input(self):
-        """Test valid input parameters."""
-        input_data = {"file_path": "/tmp/books.csv", "batch_size": 100}
-        params = BulkImportInput.model_validate(input_data)
-        assert params.file_path == "/tmp/books.csv"
-        assert params.batch_size == 100
-
-    def test_default_batch_size(self):
-        """Test default batch size is applied."""
-        input_data = {"file_path": "/tmp/books.json"}
-        params = BulkImportInput.model_validate(input_data)
-        assert params.batch_size == 50
-
-    def test_batch_size_validation(self):
-        """Test batch size constraints."""
-        # Too small
-        with pytest.raises(ValidationError):
-            BulkImportInput.model_validate({"file_path": "/tmp/books.csv", "batch_size": 0})
-
-        # Too large
-        with pytest.raises(ValidationError):
-            BulkImportInput.model_validate({"file_path": "/tmp/books.csv", "batch_size": 1001})
-
-    def test_empty_file_path(self):
-        """Test that empty file path is rejected."""
-        with pytest.raises(ValidationError):
-            BulkImportInput.model_validate({"file_path": ""})
+@pytest.fixture
+def import_root(tmp_path, monkeypatch, library):
+    """Point the allowed import root at a temp directory."""
+    root = tmp_path.resolve()
+    monkeypatch.setattr(bulk_import_module, "ALLOWED_IMPORT_ROOT", root)
+    return root
 
 
-@pytest.mark.asyncio
-class TestImportBooksFromFile:
-    """Test the core import functionality with progress reporting."""
-
-    async def test_csv_import_with_progress(self, tmp_path):
-        """Test importing books from CSV with progress notifications."""
-        # Create test CSV file
-        csv_content = """isbn,title,author_name,genre,publication_year,available_copies
-978-0-123456-78-9,Test Book 1,Author One,Fiction,2023,5
-978-0-123456-79-6,Test Book 2,Author Two,Non-Fiction,2022,3"""
-
-        csv_file = tmp_path / "test_books.csv"
-        csv_file.write_text(csv_content)
-
-        # Mock context and repository
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.bulk_import.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock database queries
-            mock_session.query.return_value.filter_by.return_value.first.return_value = None
-            mock_session.add = MagicMock()
-            mock_session.flush = MagicMock()
-            mock_session.commit = MagicMock()
-
-            result = await import_books_from_file(str(csv_file), ctx, batch_size=2)
-
-        # Verify progress reporting
-        assert ctx.report_progress.call_count >= 2  # At least once per book
-
-        # Check first progress call
-        first_call = ctx.report_progress.call_args_list[0]
-        assert first_call[1]["progress"] == 1
-        assert first_call[1]["total"] == 2
-        assert "Importing book 1/2" in first_call[1]["message"]
-
-        # Verify result
-        assert result["total_books"] == 2
-        assert result["successful_imports"] == 2
-        assert result["failed_imports"] == 0
-        assert result["success_rate"] == "100.0%"
-
-    async def test_json_import_with_progress(self, tmp_path):
-        """Test importing books from JSON with progress notifications."""
-        # Create test JSON file
-        json_data = [
-            {
-                "isbn": "978-0-123456-78-9",
-                "title": "JSON Book 1",
-                "author_name": "JSON Author",
-                "genre": "Technology",
-                "publication_year": 2023,
-                "available_copies": 4,
-            }
-        ]
-
-        json_file = tmp_path / "test_books.json"
-        json_file.write_text(json.dumps(json_data))
-
-        # Mock context
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.bulk_import.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock database queries
-            mock_session.query.return_value.filter_by.return_value.first.return_value = None
-            mock_session.add = MagicMock()
-            mock_session.flush = MagicMock()
-            mock_session.commit = MagicMock()
-
-            result = await import_books_from_file(str(json_file), ctx, batch_size=10)
-
-        # Verify progress reporting
-        progress_calls = [
-            call
-            for call in ctx.report_progress.call_args_list
-            if "Importing book" in call[1].get("message", "")
-        ]
-        assert len(progress_calls) >= 1
-
-        # Verify result
-        assert result["total_books"] == 1
-        assert result["successful_imports"] == 1
-
-    async def test_import_with_validation_errors(self, tmp_path):
-        """Test handling of validation errors during import."""
-        # Create CSV with invalid data
-        csv_content = """isbn,title,author_name,genre,publication_year,available_copies
-,Missing ISBN,Author,Fiction,2023,5
-978-0-123456-78-9,Valid Book,Author,Fiction,2023,3"""
-
-        csv_file = tmp_path / "invalid_books.csv"
-        csv_file.write_text(csv_content)
-
-        # Mock context
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.bulk_import.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock database queries
-            mock_session.query.return_value.filter_by.return_value.first.return_value = None
-            mock_session.add = MagicMock()
-            mock_session.flush = MagicMock()
-            mock_session.commit = MagicMock()
-
-            result = await import_books_from_file(str(csv_file), ctx, batch_size=10)
-
-        # Should have one warning for the invalid book
-        print(f"Warning calls: {ctx.warning.call_args_list}")
-        warning_calls = [
-            call
-            for call in ctx.warning.call_args_list
-            if "Validation error" in str(call) or "ISBN is required" in str(call)
-        ]
-        assert len(warning_calls) == 1
-
-        # Verify result
-        assert result["total_books"] == 2
-        assert result["successful_imports"] == 1
-        assert result["failed_imports"] == 1
-        assert len(result["errors"]) == 1
-
-    async def test_file_not_found(self):
-        """Test handling of non-existent file."""
-        ctx = AsyncMock(spec=Context)
-
-        with pytest.raises(FileNotFoundError, match="Import file not found"):
-            await import_books_from_file("/nonexistent/file.csv", ctx)
-
-    async def test_unsupported_file_type(self, tmp_path):
-        """Test rejection of unsupported file types."""
-        txt_file = tmp_path / "books.txt"
-        txt_file.write_text("Some text")
-
-        ctx = AsyncMock(spec=Context)
-
-        with pytest.raises(ValueError, match="Unsupported file type"):
-            await import_books_from_file(str(txt_file), ctx)
-
-
-@pytest.mark.asyncio
-class TestBulkImportBooksHandler:
-    """Test the MCP tool handler."""
-
-    async def test_successful_import(self, tmp_path):
-        """Test successful import through handler."""
-        # Create test file
-        csv_file = tmp_path / "books.csv"
-        csv_file.write_text(
-            "isbn,title,author_name,genre,publication_year,available_copies\n"
-            "978-0-123456-78-9,Test Book,Author,Fiction,2023,5"
+def _write_csv(path, rows):
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "isbn",
+                "title",
+                "author_name",
+                "genre",
+                "publication_year",
+                "available_copies",
+            ],
         )
+        writer.writeheader()
+        writer.writerows(rows)
 
-        ctx = AsyncMock(spec=Context)
 
-        with patch("tools.bulk_import.import_books_from_file") as mock_import:
-            mock_import.return_value = {
-                "total_books": 1,
-                "successful_imports": 1,
-                "failed_imports": 0,
-                "success_rate": "100.0%",
-                "errors": [],
-            }
+SAMPLE_ROWS = [
+    {
+        "isbn": "9781111111111",
+        "title": "Imported Book One",
+        "author_name": "New Author",
+        "genre": "Fiction",
+        "publication_year": 2020,
+        "available_copies": 2,
+    },
+    {
+        "isbn": "9782222222222",
+        "title": "Imported Book Two",
+        "author_name": "New Author",
+        "genre": "Science",
+        "publication_year": 2021,
+        "available_copies": 1,
+    },
+]
 
-            result = await bulk_import_books_handler(
-                {"file_path": str(csv_file), "batch_size": 50}, ctx
+
+class TestPathConfinement:
+    async def test_absolute_path_outside_root_rejected(self, import_root):
+        async with Client(server.mcp) as client:
+            with pytest.raises(ToolError, match="data directory"):
+                await client.call_tool("bulk_import_books", {"file_path": "/etc/hosts"})
+
+    async def test_traversal_outside_root_rejected(self, import_root):
+        async with Client(server.mcp) as client:
+            with pytest.raises(ToolError, match="data directory"):
+                await client.call_tool("bulk_import_books", {"file_path": "../../../etc/passwd"})
+
+    async def test_missing_file_inside_root_is_clean_error(self, import_root):
+        async with Client(server.mcp) as client:
+            with pytest.raises(ToolError, match="not found"):
+                await client.call_tool("bulk_import_books", {"file_path": "nope.csv"})
+
+    async def test_unsupported_extension_rejected(self, import_root):
+        (import_root / "books.xml").write_text("<books/>")
+        async with Client(server.mcp) as client:
+            with pytest.raises(ToolError, match="Unsupported file type"):
+                await client.call_tool("bulk_import_books", {"file_path": "books.xml"})
+
+
+class TestImportBehavior:
+    async def test_csv_import_creates_books_and_authors(self, import_root, library):
+        _write_csv(import_root / "books.csv", SAMPLE_ROWS)
+
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("bulk_import_books", {"file_path": "books.csv"})
+
+        data = result.structured_content
+        assert data["successful_imports"] == 2
+        assert data["failed_imports"] == 0
+        assert library.get(BookDB, "9781111111111").title == "Imported Book One"
+
+    async def test_json_import_with_relative_path(self, import_root, library):
+        (import_root / "books.json").write_text(json.dumps(SAMPLE_ROWS))
+
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("bulk_import_books", {"file_path": "books.json"})
+
+        assert result.structured_content["successful_imports"] == 2
+
+    async def test_duplicate_isbn_counts_as_failure(self, import_root, library):
+        rows = [dict(SAMPLE_ROWS[0]), dict(SAMPLE_ROWS[0])]  # same ISBN twice
+        _write_csv(import_root / "dupes.csv", rows)
+
+        async with Client(server.mcp) as client:
+            result = await client.call_tool("bulk_import_books", {"file_path": "dupes.csv"})
+
+        data = result.structured_content
+        assert data["successful_imports"] == 1
+        assert data["failed_imports"] == 1
+
+    async def test_progress_notifications_emitted(self, import_root, library):
+        _write_csv(import_root / "books.csv", SAMPLE_ROWS)
+        updates: list[tuple] = []
+
+        async def on_progress(progress, total, message):
+            updates.append((progress, total, message))
+
+        async with Client(server.mcp) as client:
+            await client.call_tool(
+                "bulk_import_books",
+                {"file_path": "books.csv"},
+                progress_handler=on_progress,
             )
 
-        assert not result.get("isError")
-        assert "Import completed: 1/1 books imported successfully" in result["content"][0]["text"]
-        assert result["data"]["successful_imports"] == 1
-
-    async def test_invalid_parameters(self):
-        """Test handler with invalid parameters."""
-        ctx = AsyncMock(spec=Context)
-
-        result = await bulk_import_books_handler({"file_path": "", "batch_size": 50}, ctx)
-
-        assert result["isError"]
-        assert "Invalid import parameters" in result["content"][0]["text"]
-
-    async def test_file_not_found_error(self):
-        """Test handler with non-existent file."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.bulk_import.import_books_from_file") as mock_import:
-            mock_import.side_effect = FileNotFoundError("File not found")
-
-            result = await bulk_import_books_handler({"file_path": "/nonexistent/file.csv"}, ctx)
-
-        assert result["isError"]
-        assert "File not found" in result["content"][0]["text"]
-
-    async def test_import_with_errors(self):
-        """Test handler when import has errors."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.bulk_import.import_books_from_file") as mock_import:
-            mock_import.return_value = {
-                "total_books": 10,
-                "successful_imports": 7,
-                "failed_imports": 3,
-                "success_rate": "70.0%",
-                "errors": [
-                    "Book 1: Validation error",
-                    "Book 5: Database error",
-                    "Book 8: Duplicate ISBN",
-                ],
-            }
-
-            result = await bulk_import_books_handler({"file_path": "/tmp/books.csv"}, ctx)
-
-        assert not result.get("isError")
-        content = result["content"][0]["text"]
-        assert "7/10 books imported successfully" in content
-        assert "3 imports failed" in content
-        assert "Book 1: Validation error" in content
-
-
-@pytest.mark.asyncio
-@pytest.mark.slow
-class TestLargeDatasetImport:
-    """Test import with large datasets to verify performance and progress reporting."""
-
-    async def test_10k_records_import(self, tmp_path):
-        """Test importing 10,000 books to verify progress reporting at scale."""
-        # Generate a large CSV file
-        csv_file = tmp_path / "books_10k.csv"
-
-        # Write header
-        with csv_file.open("w", newline="", encoding="utf-8") as f:
-            f.write("isbn,title,author_name,genre,publication_year,available_copies\n")
-
-            # Generate 10,000 book records
-            for i in range(10000):
-                isbn = f"978-{i // 1000:01d}-{(i // 100) % 10:01d}{(i // 10) % 10:01d}-{i % 10:01d}{i % 1000:05d}-0"
-                title = f"Book {i + 1}: A Tale of Testing"
-                author = f"Author {(i % 100) + 1}"
-                genre = ["Fiction", "Non-Fiction", "Science", "History", "Biography"][i % 5]
-                year = 2000 + (i % 24)
-                copies = (i % 5) + 1
-
-                f.write(f"{isbn},{title},{author},{genre},{year},{copies}\n")
-
-        # Mock context and database
-        ctx = AsyncMock(spec=Context)
-        progress_calls = []
-
-        # Capture progress calls
-        async def capture_progress(**kwargs):
-            progress_calls.append(
-                {
-                    "progress": kwargs.get("progress"),
-                    "total": kwargs.get("total"),
-                    "message": kwargs.get("message"),
-                    "time": time.time(),
-                }
-            )
-
-        ctx.report_progress.side_effect = capture_progress
-
-        with patch("tools.bulk_import.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock database to accept all imports quickly
-            mock_session.query.return_value.filter_by.return_value.first.return_value = None
-            mock_session.add = MagicMock()
-            mock_session.flush = MagicMock()
-            mock_session.commit = MagicMock()
-
-            # Time the import
-            start_time = time.time()
-
-            result = await import_books_from_file(
-                str(csv_file),
-                ctx,
-                batch_size=500,  # Larger batch size for performance
-            )
-
-            elapsed_time = time.time() - start_time
-
-        # Verify the import completed successfully
-        assert result["total_books"] == 10000
-        assert result["successful_imports"] == 10000
-        assert result["failed_imports"] == 0
-
-        # Verify progress was reported at reasonable intervals
-        assert len(progress_calls) >= 20  # At least every 500 books
-        assert progress_calls[0]["progress"] == 1
-        assert progress_calls[-1]["progress"] == 10000
-
-        # Verify ETA was included in progress messages
-        eta_messages = [call for call in progress_calls if "ETA:" in call["message"]]
-        assert len(eta_messages) > 0, "ETA should be reported in progress messages"
-
-        # Verify the operation completed in reasonable time (should be fast with mocks)
-        assert elapsed_time < 60, (
-            f"Import of 10K records took {elapsed_time:.1f}s, should be under 60s"
-        )
-
-        # Verify progress reporting intervals were reasonable
-        if len(progress_calls) > 2:
-            # Check that progress updates weren't all bunched at the end
-            first_interval = progress_calls[1]["time"] - progress_calls[0]["time"]
-            last_interval = progress_calls[-1]["time"] - progress_calls[-2]["time"]
-            # Intervals should be somewhat consistent (not 10x different)
-            assert last_interval < first_interval * 10, (
-                "Progress reporting should be consistent throughout"
-            )
+        assert updates, "expected progress notifications during import"
+        final = updates[-1]
+        assert final[0] == final[1]  # progress == total at completion

--- a/virtual-library-mcp/tests/tools/test_catalog_maintenance.py
+++ b/virtual-library-mcp/tests/tools/test_catalog_maintenance.py
@@ -1,384 +1,73 @@
-"""Tests for catalog maintenance tool with progress notifications."""
-
-from unittest.mock import AsyncMock, MagicMock, patch
+"""Tests for catalog maintenance: progress, ToolResult, and maintenance mode."""
 
 import pytest
-from fastmcp import Context
+from fastmcp import Client
 
-from tools.catalog_maintenance import (
-    _generate_recommendations_cache,
-    _rebuild_search_indexes,
-    _update_circulation_stats,
-    _verify_data_integrity,
-    regenerate_catalog,
-    regenerate_catalog_handler,
-)
+import server
 
 
-@pytest.mark.asyncio
-class TestDataIntegrityCheck:
-    """Test data integrity verification stage."""
-
-    async def test_verify_data_integrity_clean(self):
-        """Test integrity check with no issues."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock clean data
-            mock_query = MagicMock()
-            mock_session.query.return_value = mock_query
-            mock_query.scalar.side_effect = [
-                100,  # Total books
-            ]
-            mock_query.filter.return_value.scalar.side_effect = [
-                0,  # Orphaned books
-                0,  # Invalid circulations
-            ]
-
-            result = await _verify_data_integrity(ctx, 0, 20)
-
-        # Verify progress reporting
-        progress_calls = ctx.report_progress.call_args_list
-        assert len(progress_calls) >= 3
-
-        # Check progress values
-        assert progress_calls[-1][1]["progress"] == 20
-        assert progress_calls[-1][1]["total"] == 100
-
-        # Verify result
-        assert result["books_checked"] == 100
-        assert result["orphaned_books"] == 0
-        assert result["invalid_circulations"] == 0
-
-        # No warnings should be issued
-        assert ctx.warning.call_count == 0
-
-    async def test_verify_data_integrity_with_issues(self):
-        """Test integrity check with data issues."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock data with issues
-            mock_query = MagicMock()
-            mock_session.query.return_value = mock_query
-            mock_query.scalar.side_effect = [
-                100,  # Total books
-            ]
-            mock_query.filter.return_value.scalar.side_effect = [
-                5,  # Orphaned books
-                3,  # Invalid circulations
-            ]
-
-            result = await _verify_data_integrity(ctx, 0, 20)
-
-        # Verify warnings were issued
-        assert ctx.warning.call_count == 2
-        warning_messages = [call[0][0] for call in ctx.warning.call_args_list]
-        assert any("5 books without authors" in msg for msg in warning_messages)
-        assert any("3 invalid circulation records" in msg for msg in warning_messages)
-
-        # Verify result
-        assert result["orphaned_books"] == 5
-        assert result["invalid_circulations"] == 3
+@pytest.fixture
+async def client(library):
+    async with Client(server.mcp) as c:
+        yield c
 
 
-@pytest.mark.asyncio
-class TestSearchIndexRebuilding:
-    """Test search index rebuilding stage."""
-
-    async def test_rebuild_search_indexes(self):
-        """Test rebuilding search indexes with progress."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock counts
-            mock_session.query().scalar.side_effect = [
-                250,  # Total books
-                30,  # Total authors
-                15,  # Unique genres
-            ]
-
-            result = await _rebuild_search_indexes(ctx, 20, 50)
-
-        # Verify progress reporting for batch processing
-        progress_calls = ctx.report_progress.call_args_list
-        batch_progress_calls = [
-            call for call in progress_calls if "Indexing books" in call[1].get("message", "")
-        ]
-        assert len(batch_progress_calls) >= 2  # At least 2 batches for 250 books
-
-        # Verify final progress
-        assert progress_calls[-1][1]["progress"] == 50
-
-        # Verify info logging
-        info_calls = ctx.info.call_args_list
-        assert any("Indexed 250 books" in str(call) for call in info_calls)
-
-        # Verify result
-        assert result["books_indexed"] == 250
-        assert result["authors_indexed"] == 30
-        assert result["genres_indexed"] == 15
-
-
-@pytest.mark.asyncio
-class TestCirculationStatsUpdate:
-    """Test circulation statistics update stage."""
-
-    async def test_update_circulation_stats(self):
-        """Test updating circulation statistics."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_repo = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock circulation data
-            mock_repo.get_active_loans.return_value = ["loan1", "loan2", "loan3"]
-            mock_repo.get_overdue_loans.return_value = ["loan2"]
-            mock_session.query().scalar.return_value = 500  # Total circulations
-
-            with patch("tools.catalog_maintenance.CirculationRepository", return_value=mock_repo):
-                result = await _update_circulation_stats(ctx, 50, 80)
-
-        # Verify progress reporting
-        progress_calls = ctx.report_progress.call_args_list
-        assert progress_calls[-1][1]["progress"] == 80
-
-        # Verify warning for overdue loans
-        assert ctx.warning.call_count == 1
-        assert "Found 1 overdue loans" in ctx.warning.call_args[0][0]
-
-        # Verify result
-        assert result["active_loans"] == 3
-        assert result["overdue_loans"] == 1
-        assert result["total_circulations"] == 500
-        assert result["popular_books_updated"] == 50
-
-
-@pytest.mark.asyncio
-class TestRecommendationsCache:
-    """Test recommendations cache generation stage."""
-
-    async def test_generate_recommendations_cache(self):
-        """Test generating recommendations cache with progress."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.session_scope") as mock_session_scope:
-            mock_session = MagicMock()
-            mock_patron_repo = MagicMock()
-            mock_session_scope.return_value.__enter__.return_value = mock_session
-
-            # Mock patron data
-            mock_patrons = MagicMock()
-            mock_patrons.items = [f"patron{i}" for i in range(25)]
-            mock_patron_repo.list.return_value = mock_patrons
-
-            with patch("tools.catalog_maintenance.PatronRepository", return_value=mock_patron_repo):
-                result = await _generate_recommendations_cache(ctx, 80, 100)
-
-        # Verify progress reporting for batches
-        progress_calls = ctx.report_progress.call_args_list
-        batch_progress_calls = [
-            call
-            for call in progress_calls
-            if "Generating recommendations" in call[1].get("message", "")
-        ]
-        assert len(batch_progress_calls) >= 2  # At least 2 batches for 25 patrons
-
-        # Verify final progress
-        assert progress_calls[-1][1]["progress"] == 100
-        assert "Recommendations cache generated" in progress_calls[-1][1]["message"]
-
-        # Verify info logging
-        assert ctx.info.call_count == 1
-        assert "Generated 125 recommendations for 25 patrons" in ctx.info.call_args[0][0]
-
-        # Verify result
-        assert result["patrons_processed"] == 25
-        assert result["recommendations_generated"] == 125  # 5 per patron
-        assert result["cache_size_kb"] == 250  # 2KB per recommendation
-
-
-@pytest.mark.asyncio
 class TestRegenerateCatalog:
-    """Test the main regenerate catalog function."""
+    async def test_returns_summary_and_structured_content(self, client):
+        result = await client.call_tool("regenerate_catalog", {})
 
-    async def test_regenerate_catalog_full_flow(self):
-        """Test full catalog regeneration with all stages."""
-        ctx = AsyncMock(spec=Context)
+        # ToolResult carries BOTH a human summary and machine-readable data.
+        assert "completed successfully" in result.content[0].text
+        data = result.structured_content
+        assert data["status"] == "completed"
+        assert set(data) >= {
+            "integrity_check",
+            "search_indexes",
+            "circulation_stats",
+            "recommendations_cache",
+        }
 
-        # Mock all stage functions
-        with patch("tools.catalog_maintenance._verify_data_integrity") as mock_verify:
-            mock_verify.return_value = {
-                "books_checked": 100,
-                "orphaned_books": 0,
-                "invalid_circulations": 0,
-            }
+    async def test_counts_reflect_seeded_library(self, client):
+        result = await client.call_tool("regenerate_catalog", {})
+        data = result.structured_content
+        assert data["integrity_check"]["books_checked"] == 2
+        assert data["circulation_stats"]["active_loans"] >= 0
+        assert data["recommendations_cache"]["patrons_processed"] == 3
 
-            with patch("tools.catalog_maintenance._rebuild_search_indexes") as mock_rebuild:
-                mock_rebuild.return_value = {
-                    "books_indexed": 100,
-                    "authors_indexed": 20,
-                    "genres_indexed": 10,
-                }
+    async def test_progress_spans_all_stages(self, client):
+        updates: list[float] = []
 
-                with patch("tools.catalog_maintenance._update_circulation_stats") as mock_stats:
-                    mock_stats.return_value = {
-                        "active_loans": 15,
-                        "overdue_loans": 2,
-                        "total_circulations": 200,
-                        "popular_books_updated": 50,
-                    }
+        async def on_progress(progress, total, message):
+            updates.append(progress)
 
-                    with patch(
-                        "tools.catalog_maintenance._generate_recommendations_cache"
-                    ) as mock_cache:
-                        mock_cache.return_value = {
-                            "patrons_processed": 30,
-                            "recommendations_generated": 150,
-                            "cache_size_kb": 300,
-                        }
+        await client.call_tool("regenerate_catalog", {}, progress_handler=on_progress)
+        assert updates[-1] == 100
+        assert min(updates) < 25  # early-stage progress was reported too
 
-                        result = await regenerate_catalog(ctx)
+    async def test_recommendations_resource_restored_after_maintenance(self, client):
+        """Maintenance disables the recommendations resource, then re-enables
+        it (firing list_changed both times). Afterwards it must be visible."""
+        await client.call_tool("regenerate_catalog", {})
+        templates = await client.list_resource_templates()
+        names = {t.name for t in templates}
+        assert "Personalized Book Recommendations" in names
 
-        # Verify all stages were called with correct progress ranges
-        mock_verify.assert_called_once_with(ctx, 0, 20)
-        mock_rebuild.assert_called_once_with(ctx, 20, 50)
-        mock_stats.assert_called_once_with(ctx, 50, 80)
-        mock_cache.assert_called_once_with(ctx, 80, 100)
+    async def test_list_changed_notifications_fired(self, library):
+        """Clients receive resources/list_changed for disable and enable."""
+        import asyncio
 
-        # Verify stage announcements
-        info_calls = [call[0][0] for call in ctx.info.call_args_list]
-        assert "Starting catalog regeneration" in info_calls
-        assert "Stage 1: Verifying data integrity" in info_calls
-        assert "Stage 2: Rebuilding search indexes" in info_calls
-        assert "Stage 3: Updating circulation statistics" in info_calls
-        assert "Stage 4: Generating recommendations cache" in info_calls
-        assert "Catalog regeneration completed successfully" in info_calls
+        from fastmcp.client.messages import MessageHandler
 
-        # Verify final progress
-        final_progress = ctx.report_progress.call_args_list[-1]
-        assert final_progress[1]["progress"] == 100
-        assert final_progress[1]["total"] == 100
-        assert "Catalog regeneration complete" in final_progress[1]["message"]
+        seen: list[str] = []
 
-        # Verify result structure
-        assert result["status"] == "completed"
-        assert "integrity_check" in result
-        assert "search_indexes" in result
-        assert "circulation_stats" in result
-        assert "recommendations_cache" in result
+        class Recorder(MessageHandler):
+            async def on_resource_list_changed(self, notification) -> None:
+                seen.append("resources/list_changed")
 
+        async with Client(server.mcp, message_handler=Recorder()) as client:
+            await client.call_tool("regenerate_catalog", {})
+            # Notifications ride the stream asynchronously; yield so the
+            # client task can process them before we assert.
+            await asyncio.sleep(0.1)
 
-@pytest.mark.asyncio
-class TestRegenerateCatalogHandler:
-    """Test the MCP tool handler."""
-
-    async def test_successful_regeneration(self):
-        """Test successful catalog regeneration through handler."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.regenerate_catalog") as mock_regenerate:
-            mock_regenerate.return_value = {
-                "status": "completed",
-                "integrity_check": {
-                    "books_checked": 100,
-                    "orphaned_books": 0,
-                    "invalid_circulations": 0,
-                },
-                "search_indexes": {
-                    "books_indexed": 100,
-                    "authors_indexed": 20,
-                    "genres_indexed": 10,
-                },
-                "circulation_stats": {
-                    "active_loans": 15,
-                    "overdue_loans": 2,
-                    "total_circulations": 200,
-                    "popular_books_updated": 50,
-                },
-                "recommendations_cache": {
-                    "patrons_processed": 30,
-                    "recommendations_generated": 150,
-                    "cache_size_kb": 300,
-                },
-            }
-
-            result = await regenerate_catalog_handler({}, ctx)
-
-        assert not result.get("isError")
-        content = result["content"][0]["text"]
-
-        # Verify summary content
-        assert "Catalog regeneration completed successfully!" in content
-        assert "✓ Data Integrity: 100 books checked" in content
-        assert "✓ Search Indexes: 100 books, 20 authors, 10 genres indexed" in content
-        assert "✓ Circulation Stats: 15 active loans, 2 overdue" in content
-        assert "✓ Recommendations: Generated for 30 patrons" in content
-
-        # Verify data is included
-        assert result["data"]["status"] == "completed"
-
-    async def test_regeneration_with_warnings(self):
-        """Test handler output when integrity issues are found."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.regenerate_catalog") as mock_regenerate:
-            mock_regenerate.return_value = {
-                "status": "completed",
-                "integrity_check": {
-                    "books_checked": 100,
-                    "orphaned_books": 5,
-                    "invalid_circulations": 3,
-                },
-                "search_indexes": {
-                    "books_indexed": 100,
-                    "authors_indexed": 20,
-                    "genres_indexed": 10,
-                },
-                "circulation_stats": {
-                    "active_loans": 15,
-                    "overdue_loans": 0,
-                    "total_circulations": 200,
-                    "popular_books_updated": 50,
-                },
-                "recommendations_cache": {
-                    "patrons_processed": 30,
-                    "recommendations_generated": 150,
-                    "cache_size_kb": 300,
-                },
-            }
-
-            result = await regenerate_catalog_handler({}, ctx)
-
-        assert not result.get("isError")
-        content = result["content"][0]["text"]
-
-        # Verify warnings are included
-        assert "⚠ 5 orphaned books found" in content
-        assert "⚠ 3 invalid circulations found" in content
-
-    async def test_handler_error_handling(self):
-        """Test handler error handling."""
-        ctx = AsyncMock(spec=Context)
-
-        with patch("tools.catalog_maintenance.regenerate_catalog") as mock_regenerate:
-            mock_regenerate.side_effect = Exception("Database connection failed")
-
-            result = await regenerate_catalog_handler({}, ctx)
-
-        assert result["isError"]
-        assert (
-            "Catalog regeneration failed: Database connection failed"
-            in result["content"][0]["text"]
-        )
+        assert len(seen) >= 2  # one for disable, one for enable

--- a/virtual-library-mcp/tests/tools/test_circulation.py
+++ b/virtual-library-mcp/tests/tools/test_circulation.py
@@ -1,707 +1,163 @@
-"""
-Tests for circulation tools (checkout, return, reserve).
+"""Tests for circulation tools (checkout, return, reserve) over the protocol.
 
-These tests demonstrate comprehensive testing of MCP tools:
-1. Input validation
-2. Success scenarios
-3. Error handling
-4. Business rule enforcement
-5. State modifications
+Highlights:
+- checkout_book's elicitation flow: a patron with outstanding fines
+  triggers a server-initiated confirmation that the client must answer
+- ToolError for business-rule violations (model-recoverable errors)
+- structured output for every circulation operation
 """
-
-from contextlib import contextmanager
-from datetime import date, datetime, timedelta
 
 import pytest
-
-from database.schema import (
-    Author as AuthorDB,
-)
-from database.schema import (
-    Book as BookDB,
-)
-from database.schema import (
-    CheckoutRecord as CheckoutDB,
-)
-from database.schema import (
-    CirculationStatusEnum,
-    ReservationStatusEnum,
-)
-from database.schema import (
-    Patron as PatronDB,
-)
-from database.schema import (
-    ReservationRecord as ReservationDB,
-)
-from database.schema import (
-    ReturnRecord as ReturnDB,
-)
-from tools.circulation import (
-    checkout_book_handler,
-    reserve_book_handler,
-    return_book_handler,
-)
-
-
-class TestCheckoutBookTool:
-    """Test the checkout_book MCP tool."""
-
-    @pytest.fixture
-    def setup_test_data(self, test_db_session):
-        """Create test patron and book for checkout tests."""
-        # Create test author
-        author = AuthorDB(
-            id="author_test001",
-            name="Test Author",
-            birth_date=date(1970, 1, 1),
-        )
-        test_db_session.add(author)
-
-        # Create a test patron
-        patron = PatronDB(
-            id="patron_test001",
-            name="Test Patron",
-            email="test@example.com",
-            membership_date=date.today(),
-            status="active",
-            borrowing_limit=5,
-            current_checkouts=0,
-            outstanding_fines=0.0,
-        )
-        test_db_session.add(patron)
-
-        # Create a test book
-        book = BookDB(
-            isbn="9780134685991",
-            title="Test Book",
-            author_id="author_test001",
-            genre="Fiction",
-            publication_year=2023,
-            available_copies=3,
-            total_copies=5,
-        )
-        test_db_session.add(book)
-
-        test_db_session.commit()
-        return patron, book
-
-    async def test_checkout_success(self, setup_test_data, mock_get_session):
-        """Test successful book checkout."""
-        patron, book = setup_test_data
-
-        # Execute checkout
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        # Verify success response
-        assert "isError" not in result or not result["isError"]
-        assert "content" in result
-        assert result["content"][0]["type"] == "text"
-        assert "Successfully checked out book" in result["content"][0]["text"]
-        assert "Due date:" in result["content"][0]["text"]
-
-        # Verify structured data
-        assert "data" in result
-        assert result["data"]["checkout"]["patron_id"] == patron.id
-        assert result["data"]["checkout"]["book_isbn"] == book.isbn
-        assert result["data"]["checkout"]["status"] == "active"
-        assert result["data"]["checkout"]["loan_period_days"] == 14
-
-        # Verify database state changes
-        # Use the mock_get_session directly since it's the test session
-        # Check book availability decreased
-        updated_book = mock_get_session.get(BookDB, book.isbn)
-        assert updated_book.available_copies == 2
-
-        # Check patron checkout count increased
-        updated_patron = mock_get_session.get(PatronDB, patron.id)
-        assert updated_patron.current_checkouts == 1
-        assert updated_patron.total_checkouts == 1
-
-        # Check checkout record created
-        checkout = (
-            mock_get_session.query(CheckoutDB)
-            .filter_by(patron_id=patron.id, book_isbn=book.isbn)
-            .first()
-        )
-        assert checkout is not None
-        assert checkout.status == CirculationStatusEnum.ACTIVE
-
-    async def test_checkout_with_custom_due_date(self, setup_test_data, mock_get_session):
-        """Test checkout with custom due date."""
-        patron, book = setup_test_data
-        custom_due_date = date.today() + timedelta(days=21)
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-                "due_date": custom_due_date.isoformat(),
-                "notes": "Extended loan for research",
-            }
-        )
-
-        assert "isError" not in result or not result["isError"]
-        assert result["data"]["checkout"]["due_date"] == custom_due_date.isoformat()
-        assert result["data"]["checkout"]["loan_period_days"] == 21
-
-        # Verify notes saved
-        checkout = (
-            mock_get_session.query(CheckoutDB)
-            .filter_by(patron_id=patron.id, book_isbn=book.isbn)
-            .first()
-        )
-        assert checkout.notes == "Extended loan for research"
-
-    async def test_checkout_invalid_patron_id(self, mock_get_session):
-        """Test checkout with invalid patron ID format."""
-        result = await checkout_book_handler(
-            {
-                "patron_id": "invalid-format",
-                "book_isbn": "9780134685991",
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Invalid parameters" in result["content"][0]["text"]
-        assert "patron_id" in result["content"][0]["text"].lower()
-
-    async def test_checkout_patron_not_found(self, setup_test_data, mock_get_session):
-        """Test checkout with non-existent patron."""
-        _, book = setup_test_data
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": "patron_nonexistent",
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Patron patron_nonexistent not found" in result["content"][0]["text"]
-
-    async def test_checkout_book_not_found(self, setup_test_data, mock_get_session):
-        """Test checkout with non-existent book."""
-        patron, _ = setup_test_data
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": "9999999999999",
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Book 9999999999999 not found" in result["content"][0]["text"]
-
-    async def test_checkout_book_unavailable(self, setup_test_data, mock_get_session):
-        """Test checkout when no copies available."""
-        patron, book = setup_test_data
-
-        # Set available copies to 0
-        # Using mocked session directly
-        book_db = mock_get_session.get(BookDB, book.isbn)
-        book_db.available_copies = 0
-        mock_get_session.commit()
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Book unavailable for checkout" in result["content"][0]["text"]
-        assert "no copies" in result["content"][0]["text"]
-
-    async def test_checkout_patron_limit_exceeded(self, setup_test_data, mock_get_session):
-        """Test checkout when patron has reached borrowing limit."""
-        patron, book = setup_test_data
-
-        # Set patron at borrowing limit
-        # Using mocked session directly
-        patron_db = mock_get_session.get(PatronDB, patron.id)
-        patron_db.current_checkouts = patron_db.borrowing_limit
-        mock_get_session.commit()
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "borrowing limit" in result["content"][0]["text"]
-
-    async def test_checkout_patron_inactive(self, setup_test_data, mock_get_session):
-        """Test checkout with inactive patron membership."""
-        patron, book = setup_test_data
-
-        # Make patron inactive
-        # Using mocked session directly
-        patron_db = mock_get_session.get(PatronDB, patron.id)
-        patron_db.status = "suspended"
-        mock_get_session.commit()
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "membership is not active" in result["content"][0]["text"]
-
-    async def test_checkout_due_date_in_past(self, setup_test_data, mock_get_session):
-        """Test checkout with past due date."""
-        patron, book = setup_test_data
-        past_date = date.today() - timedelta(days=1)
-
-        result = await checkout_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-                "due_date": past_date.isoformat(),
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Due date cannot be in the past" in result["content"][0]["text"]
-
-
-class TestReturnBookTool:
-    """Test the return_book MCP tool."""
-
-    @pytest.fixture
-    def setup_checkout(self, test_db_session):
-        """Create a checkout to test returns."""
-        # Create test author
-        author = AuthorDB(
-            id="author_test001",
-            name="Test Author",
-            birth_date=date(1970, 1, 1),
-        )
-        test_db_session.add(author)
-
-        # Create patron and book
-        patron = PatronDB(
-            id="patron_return001",
-            name="Return Test Patron",
-            email="return@example.com",
-            membership_date=date.today(),
-            status="active",
-            current_checkouts=1,
-            outstanding_fines=0.0,
-        )
-        test_db_session.add(patron)
-
-        book = BookDB(
-            isbn="9780134685992",
-            title="Return Test Book",
-            author_id="author_test001",
-            genre="Fiction",
-            publication_year=2023,
-            available_copies=2,
-            total_copies=3,
-        )
-        test_db_session.add(book)
-
-        # Create active checkout
-        checkout = CheckoutDB(
-            id="checkout_20240101000001",
-            patron_id=patron.id,
-            book_isbn=book.isbn,
-            checkout_date=datetime.now() - timedelta(days=7),
-            due_date=date.today() + timedelta(days=7),
-            status=CirculationStatusEnum.ACTIVE,
-        )
-        test_db_session.add(checkout)
-
-        test_db_session.commit()
-        return checkout, patron, book
-
-    async def test_return_success(self, setup_checkout, mock_get_session):
-        """Test successful book return."""
-        checkout, patron, book = setup_checkout
-
-        result = await return_book_handler(
-            {
-                "checkout_id": checkout.id,
-            }
-        )
-
-        # Verify success response
-        assert "isError" not in result or not result["isError"]
-        assert "Successfully returned book" in result["content"][0]["text"]
-        assert "Returned on time - no fines" in result["content"][0]["text"]
-
-        # Verify structured data
-        assert result["data"]["return"]["checkout_id"] == checkout.id
-        assert result["data"]["return"]["late_days"] == 0
-        assert result["data"]["return"]["fine_assessed"] == 0.0
-
-        # Verify database state changes
-        # Using mocked session directly
-        # Check checkout marked complete
-        updated_checkout = mock_get_session.get(CheckoutDB, checkout.id)
-        assert updated_checkout.status == CirculationStatusEnum.COMPLETED
-        assert updated_checkout.return_date is not None
-
-        # Check book availability increased
-        updated_book = mock_get_session.get(BookDB, book.isbn)
-        assert updated_book.available_copies == 3
-
-        # Check patron checkout count decreased
-        updated_patron = mock_get_session.get(PatronDB, patron.id)
-        assert updated_patron.current_checkouts == 0
-
-    async def test_return_late_with_fine(self, setup_checkout, mock_get_session):
-        """Test return of overdue book with fine calculation."""
-        checkout, _, _ = setup_checkout
-
-        # Make checkout overdue
-        # Using mocked session directly
-        checkout_db = mock_get_session.get(CheckoutDB, checkout.id)
-        checkout_db.due_date = date.today() - timedelta(days=5)
-        mock_get_session.commit()
-
-        result = await return_book_handler(
-            {
-                "checkout_id": checkout.id,
-            }
-        )
-
-        assert "isError" not in result or not result["isError"]
-        assert "5 days late" in result["content"][0]["text"]
-        assert "Fine assessed: $1.25" in result["content"][0]["text"]
-
-        assert result["data"]["return"]["late_days"] == 5
-        assert result["data"]["return"]["fine_assessed"] == 1.25
-        assert result["data"]["return"]["fine_outstanding"] == 1.25
-
-    async def test_return_with_condition_notes(self, setup_checkout, mock_get_session):
-        """Test return with book condition and notes."""
-        checkout, _, _ = setup_checkout
-
-        result = await return_book_handler(
-            {
-                "checkout_id": checkout.id,
-                "condition": "damaged",
-                "notes": "Water damage on back cover",
-                "rating": 4,
-                "review": "Great story but the ending was predictable",
-            }
-        )
-
-        assert "isError" not in result or not result["isError"]
-        assert "Book condition noted as: damaged" in result["content"][0]["text"]
-
-        # Verify condition saved
-        # Using mocked session directly
-        return_record = mock_get_session.query(ReturnDB).filter_by(checkout_id=checkout.id).first()
-        assert return_record.condition == "damaged"
-        assert return_record.notes == "Water damage on back cover"
-
-    async def test_return_checkout_not_found(self, mock_get_session):
-        """Test return with non-existent checkout."""
-        result = await return_book_handler(
-            {
-                "checkout_id": "checkout_99999999999999",
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Checkout checkout_99999999999999 not found" in result["content"][0]["text"]
-
-    async def test_return_already_returned(self, setup_checkout, mock_get_session):
-        """Test return of already returned checkout."""
-        checkout, _, _ = setup_checkout
-
-        # Mark checkout as already returned
-        # Using mocked session directly
-        checkout_db = mock_get_session.get(CheckoutDB, checkout.id)
-        checkout_db.status = CirculationStatusEnum.COMPLETED
-        mock_get_session.commit()
-
-        result = await return_book_handler(
-            {
-                "checkout_id": checkout.id,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "checkout is not active" in result["content"][0]["text"]
-
-    async def test_return_invalid_condition(self, setup_checkout, mock_get_session):
-        """Test return with invalid condition value."""
-        checkout, _, _ = setup_checkout
-
-        result = await return_book_handler(
-            {
-                "checkout_id": checkout.id,
-                "condition": "destroyed",  # Invalid value
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Invalid parameters" in result["content"][0]["text"]
-
-
-class TestReserveBookTool:
-    """Test the reserve_book MCP tool."""
-
-    @pytest.fixture
-    def setup_unavailable_book(self, test_db_session):
-        """Create a book with no available copies."""
-        # Create test author
-        author = AuthorDB(
-            id="author_test001",
-            name="Test Author",
-            birth_date=date(1970, 1, 1),
-        )
-        test_db_session.add(author)
-
-        patron = PatronDB(
-            id="patron_reserve001",
-            name="Reserve Test Patron",
-            email="reserve@example.com",
-            membership_date=date.today(),
-            status="active",
-            outstanding_fines=0.0,
-        )
-        test_db_session.add(patron)
-
-        book = BookDB(
-            isbn="9780134685993",
-            title="Popular Book",
-            author_id="author_test001",
-            genre="Fiction",
-            publication_year=2023,
-            available_copies=0,
-            total_copies=2,
-        )
-        test_db_session.add(book)
-
-        test_db_session.commit()
-        return patron, book
-
-    async def test_reserve_success(self, setup_unavailable_book, mock_get_session):
-        """Test successful book reservation."""
-        patron, book = setup_unavailable_book
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        # Verify success response
-        assert "isError" not in result or not result["isError"]
-        assert "Successfully reserved book" in result["content"][0]["text"]
-        assert "Queue position: 1" in result["content"][0]["text"]
-
-        # Verify structured data
-        assert result["data"]["reservation"]["patron_id"] == patron.id
-        assert result["data"]["reservation"]["book_isbn"] == book.isbn
-        assert result["data"]["reservation"]["queue_position"] == 1
-        assert result["data"]["reservation"]["status"] == "pending"
-
-        # Verify database state
-        # Using mocked session directly
-        reservation = (
-            mock_get_session.query(ReservationDB)
-            .filter_by(patron_id=patron.id, book_isbn=book.isbn)
-            .first()
-        )
-        assert reservation is not None
-        assert reservation.status == ReservationStatusEnum.PENDING
-        assert reservation.queue_position == 1
-
-    async def test_reserve_with_queue(self, setup_unavailable_book, mock_get_session):
-        """Test reservation when others are already in queue."""
-        patron, book = setup_unavailable_book
-
-        # Create existing reservation
-        # Using mocked session directly
-        existing_reservation = ReservationDB(
-            id="reservation_existing001",
-            patron_id="patron_other001",
-            book_isbn=book.isbn,
-            reservation_date=datetime.now() - timedelta(days=1),
-            expiration_date=date.today() + timedelta(days=30),
-            status=ReservationStatusEnum.PENDING,
-            queue_position=1,
-        )
-        mock_get_session.add(existing_reservation)
-        mock_get_session.commit()
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert "isError" not in result or not result["isError"]
-        assert "Queue position: 2" in result["content"][0]["text"]
-        assert "estimated wait: 14 days" in result["content"][0]["text"]
-
-        assert result["data"]["reservation"]["queue_position"] == 2
-        assert result["data"]["reservation"]["estimated_wait_days"] == 14
-        assert result["data"]["reservation"]["total_in_queue"] == 2
-
-    async def test_reserve_with_custom_expiration(self, setup_unavailable_book, mock_get_session):
-        """Test reservation with custom expiration date."""
-        patron, book = setup_unavailable_book
-        expiration_date = date.today() + timedelta(days=60)
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-                "expiration_date": expiration_date.isoformat(),
-                "notes": "Need for summer reading list",
-            }
-        )
-
-        assert "isError" not in result or not result["isError"]
-        assert result["data"]["reservation"]["expiration_date"] == expiration_date.isoformat()
-
-        # Verify notes saved
-        # Using mocked session directly
-        reservation = (
-            mock_get_session.query(ReservationDB)
-            .filter_by(patron_id=patron.id, book_isbn=book.isbn)
-            .first()
-        )
-        assert reservation.notes == "Need for summer reading list"
-
-    async def test_reserve_patron_not_found(self, setup_unavailable_book, mock_get_session):
-        """Test reservation with non-existent patron."""
-        _, book = setup_unavailable_book
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": "patron_nonexistent",
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Patron patron_nonexistent not found" in result["content"][0]["text"]
-
-    async def test_reserve_book_not_found(self, setup_unavailable_book, mock_get_session):
-        """Test reservation with non-existent book."""
-        patron, _ = setup_unavailable_book
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": "9999999999999",
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Book 9999999999999 not found" in result["content"][0]["text"]
-
-    async def test_reserve_book_available(self, setup_unavailable_book, mock_get_session):
-        """Test reservation attempt when book is available."""
-        patron, book = setup_unavailable_book
-
-        # Make book available
-        # Using mocked session directly
-        book_db = mock_get_session.get(BookDB, book.isbn)
-        book_db.available_copies = 1
-        mock_get_session.commit()
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Book has available copies" in result["content"][0]["text"]
-
-    async def test_reserve_duplicate_reservation(self, setup_unavailable_book, mock_get_session):
-        """Test duplicate reservation by same patron."""
-        patron, book = setup_unavailable_book
-
-        # Create first reservation
-        await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        # Try to reserve again
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-            }
-        )
-
-        assert result["isError"] is True
-        assert "already has an active reservation" in result["content"][0]["text"]
-
-    async def test_reserve_expiration_date_past(self, setup_unavailable_book, mock_get_session):
-        """Test reservation with past expiration date."""
-        patron, book = setup_unavailable_book
-        past_date = date.today() - timedelta(days=1)
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-                "expiration_date": past_date.isoformat(),
-            }
-        )
-
-        assert result["isError"] is True
-        assert "Expiration date must be in the future" in result["content"][0]["text"]
-
-    async def test_reserve_expiration_date_too_far(self, setup_unavailable_book, mock_get_session):
-        """Test reservation with expiration date too far in future."""
-        patron, book = setup_unavailable_book
-        far_date = date.today() + timedelta(days=100)
-
-        result = await reserve_book_handler(
-            {
-                "patron_id": patron.id,
-                "book_isbn": book.isbn,
-                "expiration_date": far_date.isoformat(),
-            }
-        )
-
-        assert result["isError"] is True
-        assert "cannot be more than 90 days" in result["content"][0]["text"]
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+import server
+from database.schema import Book as BookDB
+from database.schema import CheckoutRecord as CheckoutDB
+from database.schema import Patron as PatronDB
 
 
 @pytest.fixture
-def mock_get_session(test_db_session, monkeypatch):
-    """Mock get_session to return the test session.
+async def client(library):
+    """Client whose elicitation handler approves everything."""
 
-    This ensures that the circulation handlers use the same database session
-    as the test, allowing them to see the test data we create.
-    """
+    async def approve_all(message, response_type, params, context):
+        return None  # bare accept for approval-style elicitations
 
-    @contextmanager
-    def _mock_get_session():
-        """Return the test session instead of creating a new one."""
-        yield test_db_session
+    async with Client(server.mcp, elicitation_handler=approve_all) as c:
+        yield c
 
-    # Patch the get_session function in the circulation module
-    monkeypatch.setattr("tools.circulation.get_session", _mock_get_session)
 
-    return test_db_session
+class TestCheckoutBook:
+    async def test_checkout_success_updates_state(self, client, library):
+        result = await client.call_tool(
+            "checkout_book",
+            {"patron_id": "patron_clean001", "book_isbn": "9780134685991"},
+        )
+        data = result.structured_content
+        assert data["patron_id"] == "patron_clean001"
+        assert data["loan_period_days"] == 14
+
+        book = library.get(BookDB, "9780134685991")
+        assert book.available_copies == 2
+        patron = library.get(PatronDB, "patron_clean001")
+        assert patron.current_checkouts == 2
+
+    async def test_checkout_unavailable_book_is_tool_error(self, client):
+        with pytest.raises(ToolError, match=r"unavailable|no copies"):
+            await client.call_tool(
+                "checkout_book",
+                {"patron_id": "patron_clean001", "book_isbn": "9780134685007"},
+            )
+
+    async def test_checkout_unknown_patron_is_tool_error(self, client):
+        with pytest.raises(ToolError, match="not found"):
+            await client.call_tool(
+                "checkout_book",
+                {"patron_id": "patron_missing99", "book_isbn": "9780134685991"},
+            )
+
+    async def test_checkout_invalid_isbn_rejected_by_schema(self, client):
+        with pytest.raises(ToolError):
+            await client.call_tool(
+                "checkout_book", {"patron_id": "patron_clean001", "book_isbn": "not-an-isbn"}
+            )
+
+
+class TestCheckoutElicitation:
+    """A patron with fines triggers a confirmation elicitation."""
+
+    async def test_fined_patron_checkout_asks_and_proceeds_on_accept(self, library):
+        asked: list[str] = []
+
+        async def approve(message, response_type, params, context):
+            asked.append(message)
+
+        async with Client(server.mcp, elicitation_handler=approve) as client:
+            result = await client.call_tool(
+                "checkout_book",
+                {"patron_id": "patron_fines001", "book_isbn": "9780134685991"},
+            )
+        assert result.structured_content["patron_id"] == "patron_fines001"
+        assert len(asked) == 1
+        assert "$4.50" in asked[0]
+
+    async def test_fined_patron_checkout_aborts_on_decline(self, library):
+        from fastmcp.client.elicitation import ElicitResult
+
+        async def decline(message, response_type, params, context):
+            return ElicitResult(action="decline")
+
+        async with Client(server.mcp, elicitation_handler=decline) as client:
+            with pytest.raises(ToolError, match="declined"):
+                await client.call_tool(
+                    "checkout_book",
+                    {"patron_id": "patron_fines001", "book_isbn": "9780134685991"},
+                )
+
+        # No loan was created for the declined checkout.
+        checkouts = (
+            library.query(CheckoutDB).filter(CheckoutDB.patron_id == "patron_fines001").count()
+        )
+        assert checkouts == 0
+
+    async def test_clean_patron_checkout_never_elicits(self, library):
+        asked: list[str] = []
+
+        async def record(message, response_type, params, context):
+            asked.append(message)
+
+        async with Client(server.mcp, elicitation_handler=record) as client:
+            await client.call_tool(
+                "checkout_book",
+                {"patron_id": "patron_clean001", "book_isbn": "9780134685991"},
+            )
+        assert asked == []
+
+
+class TestReturnBook:
+    async def test_return_overdue_book_assesses_fine(self, client, library):
+        result = await client.call_tool(
+            "return_book", {"checkout_id": "checkout_active01", "condition": "good"}
+        )
+        data = result.structured_content
+        assert data["late_days"] == 4
+        assert data["fine_assessed"] == pytest.approx(1.0)  # 4 days * $0.25
+
+        book = library.get(BookDB, "9780134685007")
+        assert book.available_copies == 1  # restored
+
+    async def test_return_records_condition(self, client):
+        result = await client.call_tool(
+            "return_book", {"checkout_id": "checkout_active01", "condition": "damaged"}
+        )
+        assert result.structured_content["condition"] == "damaged"
+        assert "damaged" in result.structured_content["message"]
+
+    async def test_return_unknown_checkout_is_tool_error(self, client):
+        with pytest.raises(ToolError, match="not found"):
+            await client.call_tool("return_book", {"checkout_id": "checkout_nope999"})
+
+    async def test_schema_rejects_invalid_condition(self, client):
+        with pytest.raises(ToolError):
+            await client.call_tool(
+                "return_book", {"checkout_id": "checkout_active01", "condition": "obliterated"}
+            )
+
+
+class TestReserveBook:
+    async def test_reserve_unavailable_book_returns_queue_position(self, client):
+        result = await client.call_tool(
+            "reserve_book",
+            {"patron_id": "patron_fines001", "book_isbn": "9780134685007"},
+        )
+        data = result.structured_content
+        assert data["queue_position"] == 1
+        assert data["total_in_queue"] == 1
+
+    async def test_reserve_unknown_book_is_tool_error(self, client):
+        with pytest.raises(ToolError, match="not found"):
+            await client.call_tool(
+                "reserve_book",
+                {"patron_id": "patron_clean001", "book_isbn": "9999999999999"},
+            )

--- a/virtual-library-mcp/tests/tools/test_membership.py
+++ b/virtual-library-mcp/tests/tools/test_membership.py
@@ -1,0 +1,61 @@
+"""Tests for renew_membership — the enum-elicitation showcase.
+
+The renewal term is never a tool argument: the server elicits it from the
+user mid-execution (MCP 2025-11-25 elicitation with constrained options).
+"""
+
+from datetime import date, timedelta
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.elicitation import ElicitResult
+from fastmcp.exceptions import ToolError
+
+import server
+from database.schema import Patron as PatronDB
+
+
+def _term_handler(term: str):
+    async def handler(message, response_type, params, context):
+        # Constrained elicitation: FastMCP wraps the Literal options in a
+        # dataclass-like response type with a single 'value' field.
+        if response_type is None:
+            return None
+        return term
+
+    return handler
+
+
+class TestRenewMembership:
+    async def test_renewal_applies_chosen_term(self, library):
+        async with Client(server.mcp, elicitation_handler=_term_handler("12 months")) as client:
+            result = await client.call_tool("renew_membership", {"patron_id": "patron_clean001"})
+        data = result.structured_content
+        assert data["renewed"] is True
+        assert data["term"] == "12 months"
+
+        patron = library.get(PatronDB, "patron_clean001")
+        library.refresh(patron)
+        expected = date.today() + timedelta(days=200) + timedelta(days=365)
+        assert patron.expiration_date == expected
+
+    async def test_renewal_reactivates_expired_membership(self, library):
+        async with Client(server.mcp, elicitation_handler=_term_handler("6 months")) as client:
+            result = await client.call_tool("renew_membership", {"patron_id": "patron_lapsed01"})
+        assert result.structured_content["renewed"] is True
+        assert result.structured_content["status"] == "active"
+
+    async def test_declined_renewal_is_a_normal_outcome(self, library):
+        async def decline(message, response_type, params, context):
+            return ElicitResult(action="decline")
+
+        async with Client(server.mcp, elicitation_handler=decline) as client:
+            result = await client.call_tool("renew_membership", {"patron_id": "patron_clean001"})
+        data = result.structured_content
+        assert data["renewed"] is False
+        assert "decline" in data["message"]
+
+    async def test_unknown_patron_is_tool_error(self, library):
+        async with Client(server.mcp, elicitation_handler=_term_handler("6 months")) as client:
+            with pytest.raises(ToolError, match="not found"):
+                await client.call_tool("renew_membership", {"patron_id": "patron_missing99"})

--- a/virtual-library-mcp/tests/tools/test_search.py
+++ b/virtual-library-mcp/tests/tools/test_search.py
@@ -1,537 +1,99 @@
-"""
-Tests for the search_catalog tool.
+"""Tests for the search_catalog tool through the MCP protocol path.
 
-These tests verify:
-1. Input validation and error handling
-2. Search functionality across different parameters
-3. Pagination behavior
-4. Sorting options
-5. MCP protocol compliance
+These run against the real server via the FastMCP in-memory client, so
+they verify what an actual MCP client experiences: the generated input
+schema, structured output, annotations, and ToolError conversion.
 """
-
-from contextlib import contextmanager
 
 import pytest
-from pydantic import ValidationError
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
 
-from database.author_repository import AuthorCreateSchema, AuthorRepository
-from database.book_repository import BookCreateSchema, BookRepository
-from tools.search import SearchCatalogInput, search_catalog_handler
-
-# =============================================================================
-# INPUT VALIDATION TESTS
-# =============================================================================
-
-
-class TestSearchCatalogInput:
-    """Test input validation for the search tool."""
-
-    def test_valid_minimal_input(self):
-        """Test minimal valid input with just a query."""
-        params = SearchCatalogInput(query="gatsby")
-        assert params.query == "gatsby"
-        assert params.genre is None
-        assert params.author is None
-        assert params.available_only is False
-        assert params.page == 1
-        assert params.page_size == 10
-        assert params.sort_by == "relevance"
-        assert params.sort_desc is False
-
-    def test_valid_full_input(self):
-        """Test all parameters with valid values."""
-        params = SearchCatalogInput(
-            query="python",
-            genre="Technology",
-            author="Smith",
-            available_only=True,
-            page=2,
-            page_size=20,
-            sort_by="publication_year",
-            sort_desc=True,
-        )
-        assert params.query == "python"
-        assert params.genre == "Technology"  # Should be title-cased
-        assert params.author == "Smith"
-        assert params.available_only is True
-        assert params.page == 2
-        assert params.page_size == 20
-        assert params.sort_by == "publication_year"
-        assert params.sort_desc is True
-
-    def test_whitespace_stripping(self):
-        """Test that whitespace is properly stripped from string inputs."""
-        params = SearchCatalogInput(
-            query="  gatsby  ", author="  Fitzgerald  ", genre="  fiction  "
-        )
-        assert params.query == "gatsby"
-        assert params.author == "Fitzgerald"
-        assert params.genre == "Fiction"  # Also title-cased
-
-    def test_empty_strings_become_none(self):
-        """Test that empty strings after stripping become None."""
-        params = SearchCatalogInput(
-            query="   ",  # Just whitespace
-            author="   ",  # Need whitespace to avoid min_length validation
-            genre="  ",
-        )
-        assert params.query is None
-        assert params.author is None
-        assert params.genre is None
-
-    def test_genre_normalization(self):
-        """Test genre is normalized to title case."""
-        params = SearchCatalogInput(genre="science FICTION")
-        assert params.genre == "Science Fiction"
-
-    def test_invalid_page_number(self):
-        """Test validation rejects invalid page numbers."""
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="test", page=0)
-        assert "greater than or equal to 1" in str(exc_info.value)
-
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="test", page=1001)
-        assert "less than or equal to 1000" in str(exc_info.value)
-
-    def test_invalid_page_size(self):
-        """Test validation rejects invalid page sizes."""
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="test", page_size=0)
-        assert "greater than or equal to 1" in str(exc_info.value)
-
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="test", page_size=51)
-        assert "less than or equal to 50" in str(exc_info.value)
-
-    def test_invalid_sort_by(self):
-        """Test validation rejects invalid sort options."""
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="test", sort_by="invalid")
-        assert "String should match pattern" in str(exc_info.value)
-
-    def test_query_length_limits(self):
-        """Test query length validation."""
-        # Max length should be accepted
-        params = SearchCatalogInput(query="a" * 200)
-        assert len(params.query) == 200
-
-        # Too long should fail
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(query="a" * 201)
-        assert "String should have at most 200 characters" in str(exc_info.value)
-
-    def test_author_length_limits(self):
-        """Test author length validation."""
-        # Max length should be accepted
-        params = SearchCatalogInput(author="a" * 100)
-        assert len(params.author) == 100
-
-        # Too long should fail
-        with pytest.raises(ValidationError) as exc_info:
-            SearchCatalogInput(author="a" * 101)
-        assert "String should have at most 100 characters" in str(exc_info.value)
-
-
-# =============================================================================
-# TOOL HANDLER TESTS
-# =============================================================================
-
-
-@pytest.mark.asyncio
-class TestSearchCatalogHandler:
-    """Test the search_catalog tool handler."""
-
-    async def test_handler_with_invalid_arguments(self):
-        """Test handler returns error for invalid arguments."""
-        # Missing all search criteria
-        result = await search_catalog_handler({})
-        assert result["isError"] is True
-        assert "at least one search criterion" in result["content"][0]["text"]
-
-        # Invalid page number
-        result = await search_catalog_handler({"query": "test", "page": -1})
-        assert result["isError"] is True
-        assert "Invalid search parameters" in result["content"][0]["text"]
-
-        # Invalid sort_by
-        result = await search_catalog_handler({"query": "test", "sort_by": "invalid_field"})
-        assert result["isError"] is True
-        assert "Invalid search parameters" in result["content"][0]["text"]
-
-    async def test_handler_with_valid_query(self, test_session, mock_get_session):
-        """Test handler with a valid search query."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        # Create test author
-        author = author_repo.create(
-            AuthorCreateSchema(name="F. Scott Fitzgerald", biography="American novelist")
-        )
-
-        # Create test books
-        book_repo.create(
-            BookCreateSchema(
-                isbn="9780333791035",
-                title="The Great Gatsby",
-                author_id=author.id,
-                genre="Fiction",
-                publication_year=1925,
-                available_copies=2,
-                total_copies=3,
-                description="A classic American novel",
-            )
-        )
-
-        # Search for the book
-        result = await search_catalog_handler({"query": "gatsby"})
-
-        assert result.get("isError") is not True
-        assert "Found 1 book(s)" in result["content"][0]["text"]
-        assert result["data"]["books"][0]["title"] == "The Great Gatsby"
-        assert result["data"]["pagination"]["total"] == 1
-
-    async def test_handler_with_genre_filter(self, test_session, mock_get_session):
-        """Test handler with genre filtering."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        author = author_repo.create(AuthorCreateSchema(name="Test Author", biography="Test bio"))
-
-        # Create books in different genres
-        book_repo.create(
-            BookCreateSchema(
-                isbn="1111111111111",
-                title="Fiction Book",
-                author_id=author.id,
-                genre="Fiction",
-                publication_year=2020,
-                total_copies=1,
-            )
-        )
-
-        book_repo.create(
-            BookCreateSchema(
-                isbn="2222222222222",
-                title="SciFi Book",
-                author_id=author.id,
-                genre="Science Fiction",
-                publication_year=2021,
-                total_copies=1,
-            )
-        )
-
-        # Search by genre
-        result = await search_catalog_handler(
-            {
-                "genre": "fiction"  # Should be normalized to "Fiction"
-            }
-        )
-
-        assert result.get("isError") is not True
-        books = result["data"]["books"]
-        assert len(books) == 1
-        assert books[0]["genre"] == "Fiction"
-
-    async def test_handler_with_author_filter(self, test_session, mock_get_session):
-        """Test handler with author name filtering."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        fitzgerald = author_repo.create(
-            AuthorCreateSchema(name="F. Scott Fitzgerald", biography="American novelist")
-        )
-
-        hemingway = author_repo.create(
-            AuthorCreateSchema(name="Ernest Hemingway", biography="American novelist")
-        )
-
-        # Create books by different authors
-        book_repo.create(
-            BookCreateSchema(
-                isbn="1111111111111",
-                title="The Great Gatsby",
-                author_id=fitzgerald.id,
-                genre="Fiction",
-                publication_year=1925,
-                total_copies=1,
-            )
-        )
-
-        book_repo.create(
-            BookCreateSchema(
-                isbn="2222222222222",
-                title="The Sun Also Rises",
-                author_id=hemingway.id,
-                genre="Fiction",
-                publication_year=1926,
-                total_copies=1,
-            )
-        )
-
-        # Search by author name
-        result = await search_catalog_handler({"author": "fitzgerald"})
-
-        assert result.get("isError") is not True
-        books = result["data"]["books"]
-        assert len(books) == 1
-        assert books[0]["title"] == "The Great Gatsby"
-
-    async def test_handler_with_availability_filter(self, test_session, mock_get_session):
-        """Test handler with availability filtering."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        author = author_repo.create(AuthorCreateSchema(name="Test Author", biography="Test bio"))
-
-        # Create books with different availability
-        book_repo.create(
-            BookCreateSchema(
-                isbn="1111111111111",
-                title="Available Book",
-                author_id=author.id,
-                genre="Fiction",
-                publication_year=2020,
-                available_copies=2,
-                total_copies=2,
-            )
-        )
-
-        book_repo.create(
-            BookCreateSchema(
-                isbn="2222222222222",
-                title="Unavailable Book",
-                author_id=author.id,
-                genre="Fiction",
-                publication_year=2021,
-                available_copies=0,
-                total_copies=1,
-            )
-        )
-
-        # Search with availability filter
-        result = await search_catalog_handler({"genre": "Fiction", "available_only": True})
-
-        assert result.get("isError") is not True
-        books = result["data"]["books"]
-        assert len(books) == 1
-        assert books[0]["title"] == "Available Book"
-        assert books[0]["is_available"] is True
-
-    async def test_handler_pagination(self, test_session, mock_get_session):
-        """Test handler pagination behavior."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        author = author_repo.create(AuthorCreateSchema(name="Test Author", biography="Test bio"))
-
-        # Create multiple books
-        for i in range(15):
-            book_repo.create(
-                BookCreateSchema(
-                    isbn=f"{i:013d}",
-                    title=f"Book {i:02d}",
-                    author_id=author.id,
-                    genre="Fiction",
-                    publication_year=2020,  # Use a fixed valid year
-                    total_copies=1,
-                )
-            )
-
-        # Get first page
-        result = await search_catalog_handler({"genre": "Fiction", "page": 1, "page_size": 10})
-
-        assert result.get("isError") is not True
-        assert len(result["data"]["books"]) == 10
-        assert result["data"]["pagination"]["page"] == 1
-        assert result["data"]["pagination"]["total"] == 15
-        assert result["data"]["pagination"]["total_pages"] == 2
-        assert result["data"]["pagination"]["has_next"] is True
-        assert result["data"]["pagination"]["has_previous"] is False
-
-        # Get second page
-        result = await search_catalog_handler({"genre": "Fiction", "page": 2, "page_size": 10})
-
-        assert result.get("isError") is not True
-        assert len(result["data"]["books"]) == 5
-        assert result["data"]["pagination"]["page"] == 2
-        assert result["data"]["pagination"]["has_next"] is False
-        assert result["data"]["pagination"]["has_previous"] is True
-
-    async def test_handler_sorting(self, test_session, mock_get_session):
-        """Test handler sorting options."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        author = author_repo.create(AuthorCreateSchema(name="Test Author", biography="Test bio"))
-
-        # Create books with different attributes
-        books_data = [
-            ("1111111111111", "Zebra Book", 2020, 1),
-            ("2222222222222", "Alpha Book", 2022, 3),
-            ("3333333333333", "Beta Book", 2021, 0),
-        ]
-
-        for isbn, title, year, available in books_data:
-            book_repo.create(
-                BookCreateSchema(
-                    isbn=isbn,
-                    title=title,
-                    author_id=author.id,
-                    genre="Fiction",
-                    publication_year=year,
-                    available_copies=available,
-                    total_copies=3,
-                )
-            )
-
-        # Sort by title ascending (default)
-        result = await search_catalog_handler(
-            {"genre": "Fiction", "sort_by": "title", "sort_desc": False}
-        )
-
-        assert result.get("isError") is not True
-        books = result["data"]["books"]
-        assert books[0]["title"] == "Alpha Book"
-        assert books[1]["title"] == "Beta Book"
-        assert books[2]["title"] == "Zebra Book"
-
-        # Sort by publication year descending
-        result = await search_catalog_handler(
-            {"genre": "Fiction", "sort_by": "publication_year", "sort_desc": True}
-        )
-
-        books = result["data"]["books"]
-        assert books[0]["publication_year"] == 2022
-        assert books[1]["publication_year"] == 2021
-        assert books[2]["publication_year"] == 2020
-
-        # Sort by availability
-        result = await search_catalog_handler(
-            {"genre": "Fiction", "sort_by": "availability", "sort_desc": True}
-        )
-
-        books = result["data"]["books"]
-        assert books[0]["available_copies"] == 3
-        assert books[1]["available_copies"] == 1
-        assert books[2]["available_copies"] == 0
-
-    async def test_handler_no_results(self, test_session, mock_get_session):
-        """Test handler when no books match the search."""
-        result = await search_catalog_handler({"query": "nonexistent_book_xyz"})
-
-        assert result.get("isError") is not True
-        assert "No books found" in result["content"][0]["text"]
-        assert result["data"]["books"] == []
-        assert result["data"]["pagination"]["total"] == 0
-
-    async def test_handler_error_handling(self, test_session, monkeypatch):
-        """Test handler error handling for database errors."""
-
-        # Mock the search method to raise an exception
-        def mock_search(*args, **kwargs):
-            raise RuntimeError("Database connection error")
-
-        monkeypatch.setattr(BookRepository, "search", mock_search)
-
-        result = await search_catalog_handler({"query": "test"})
-
-        assert result["isError"] is True
-        assert "Search failed" in result["content"][0]["text"]
-        assert "Database connection error" in result["content"][0]["text"]
-
-    async def test_handler_combined_filters(self, test_session, mock_get_session):
-        """Test handler with multiple filters combined."""
-        # Setup test data
-        author_repo = AuthorRepository(test_session)
-        book_repo = BookRepository(test_session)
-
-        fitzgerald = author_repo.create(
-            AuthorCreateSchema(name="F. Scott Fitzgerald", biography="American novelist")
-        )
-
-        # Create multiple books
-        book_repo.create(
-            BookCreateSchema(
-                isbn="1111111111111",
-                title="The Great Gatsby",
-                author_id=fitzgerald.id,
-                genre="Fiction",
-                publication_year=1925,
-                available_copies=2,
-                total_copies=2,
-                description="A story about the American Dream",
-            )
-        )
-
-        book_repo.create(
-            BookCreateSchema(
-                isbn="2222222222222",
-                title="Tender Is the Night",
-                author_id=fitzgerald.id,
-                genre="Fiction",
-                publication_year=1934,
-                available_copies=0,
-                total_copies=1,
-                description="A novel about a psychiatrist",
-            )
-        )
-
-        # Search with multiple filters
-        result = await search_catalog_handler(
-            {
-                "query": "american",  # Should match Gatsby's description
-                "author": "fitzgerald",
-                "genre": "Fiction",
-                "available_only": True,
-            }
-        )
-
-        assert result.get("isError") is not True
-        books = result["data"]["books"]
-        assert len(books) == 1
-        assert books[0]["title"] == "The Great Gatsby"
-        assert books[0]["is_available"] is True
-
-
-# =============================================================================
-# FIXTURES
-# =============================================================================
+import server
 
 
 @pytest.fixture
-def test_session(test_db_session):
-    """Provide a test database session."""
-    # Import at module level is preferred, but we need it here for test isolation
-    from database.schema import Base
-
-    # Create tables
-    engine = test_db_session.bind
-    Base.metadata.create_all(bind=engine)
-
-    return test_db_session
+async def client(library):
+    async with Client(server.mcp) as c:
+        yield c
 
 
-@pytest.fixture
-def mock_get_session(test_session, monkeypatch):
-    """Mock get_session to return the test session.
+class TestSearchSchema:
+    """The generated input schema is the contract the LLM sees."""
 
-    This ensures that the search handler uses the same database session
-    as the test, allowing it to see the test data we create.
-    """
+    async def test_input_schema_has_real_parameters(self, client):
+        tools = {t.name: t for t in await client.list_tools()}
+        schema = tools["search_catalog"].inputSchema
+        assert set(schema["properties"]) >= {
+            "query",
+            "genre",
+            "author",
+            "available_only",
+            "page",
+            "page_size",
+            "sort_by",
+            "sort_desc",
+        }
 
-    @contextmanager
-    def _mock_get_session():
-        """Return the test session instead of creating a new one."""
-        yield test_session
+    async def test_output_schema_published(self, client):
+        tools = {t.name: t for t in await client.list_tools()}
+        out = tools["search_catalog"].outputSchema
+        assert out is not None
+        assert "books" in out["properties"]
 
-    # Patch the get_session function in the search module
-    monkeypatch.setattr("tools.search.get_session", _mock_get_session)
+    async def test_annotations_mark_read_only(self, client):
+        tools = {t.name: t for t in await client.list_tools()}
+        annotations = tools["search_catalog"].annotations
+        assert annotations is not None
+        assert annotations.readOnlyHint is True
 
-    return test_session
+    async def test_components_have_icons(self, client):
+        """SEP-973: tools expose icon metadata for client UIs."""
+        tools = {t.name: t for t in await client.list_tools()}
+        icons = tools["search_catalog"].icons
+        assert icons
+        assert icons[0].src.startswith("data:image/svg+xml")
+
+
+class TestSearchBehavior:
+    async def test_search_by_query(self, client):
+        result = await client.call_tool("search_catalog", {"query": "Available"})
+        data = result.structured_content
+        assert data["pagination"]["total"] == 1
+        assert data["books"][0]["title"] == "The Available Book"
+        assert data["books"][0]["is_available"] is True
+
+    async def test_search_by_genre_is_case_insensitive(self, client):
+        result = await client.call_tool("search_catalog", {"genre": "science fiction"})
+        data = result.structured_content
+        assert data["pagination"]["total"] == 1
+        assert data["books"][0]["isbn"] == "9780134685007"
+
+    async def test_search_by_author_partial_match(self, client):
+        result = await client.call_tool("search_catalog", {"author": "test"})
+        assert result.structured_content["pagination"]["total"] == 2
+
+    async def test_available_only_filters_out_zero_copy_books(self, client):
+        result = await client.call_tool(
+            "search_catalog", {"genre": "Science Fiction", "available_only": True}
+        )
+        assert result.structured_content["pagination"]["total"] == 0
+
+    async def test_no_criteria_is_a_tool_error(self, client):
+        with pytest.raises(ToolError, match="at least one search criterion"):
+            await client.call_tool("search_catalog", {})
+
+    async def test_schema_rejects_out_of_range_page(self, client):
+        with pytest.raises(ToolError):
+            await client.call_tool("search_catalog", {"query": "x", "page": 0})
+
+    async def test_no_results_message(self, client):
+        result = await client.call_tool("search_catalog", {"query": "zzz-no-such-book"})
+        assert "No books found" in result.structured_content["summary"]
+
+    async def test_pagination_metadata(self, client):
+        result = await client.call_tool("search_catalog", {"author": "test", "page_size": 1})
+        page = result.structured_content["pagination"]
+        assert page["total"] == 2
+        assert page["total_pages"] == 2
+        assert page["has_next"] is True

--- a/virtual-library-mcp/tools/__init__.py
+++ b/virtual-library-mcp/tools/__init__.py
@@ -1,50 +1,152 @@
 """
 MCP Tools for the Virtual Library Server.
 
-This module implements MCP tools - actions with side effects that allow
-LLMs to interact with the library system. Unlike resources (read-only),
-tools can modify state, perform searches, and execute operations.
+Tools are the MCP primitive for actions with side effects — the "POST"
+half of the protocol, where resources are the "GET" half. Each tool here
+is a plain typed Python function; FastMCP derives the JSON Schema the
+client sees from the signature (names, types, constraints, docs).
 
-MCP TOOLS ARCHITECTURE:
-Tools in the Model Context Protocol are:
-1. Actions that can have side effects (create, update, delete)
-2. Defined with JSON Schema for input validation
-3. Invoked by clients via tools/call requests
-4. Return results or errors in a structured format
+Registration happens in register(), which attaches per-tool protocol
+metadata from the MCP 2025-11-25 revision:
 
-The tools module follows MCP best practices:
-- Clear separation between read (resources) and write (tools) operations
-- Comprehensive input validation using Pydantic schemas
-- Proper error handling with meaningful messages
-- Atomic operations with rollback on failure
+- ToolAnnotations: behavioral hints (readOnlyHint, destructiveHint,
+  idempotentHint, openWorldHint) that let clients build better UX —
+  e.g. skipping confirmation prompts for read-only tools
+- Icons (SEP-973): visual identity for client UIs
+- Tags: server-side grouping for visibility control
+- Background tasks (SEP-1686): regenerate_catalog can run as a pollable
+  task for clients that request it
 """
 
-from .book_insights import generate_book_insights_tool
+from fastmcp import FastMCP
+from fastmcp.server.tasks import TaskConfig
+from mcp.types import ToolAnnotations
+
+from icons import BOOK_ICON, CARD_ICON, MAINTENANCE_ICON, SEARCH_ICON, SPARKLE_ICON
+
+from .book_insights import generate_book_insights
 from .bulk_import import bulk_import_books
-from .catalog_maintenance import regenerate_catalog_tool
+from .catalog_maintenance import regenerate_catalog
 from .circulation import checkout_book, reserve_book, return_book
+from .membership import renew_membership
 from .search import search_catalog
 
-# Export all tools for server registration
-# WHY: The server needs a single list of all available tools
-# HOW: Each tool is a dictionary with metadata and handler
-# WHAT: This list is used during server initialization
-all_tools = [
-    search_catalog,
-    checkout_book,
-    return_book,
-    reserve_book,
-    bulk_import_books,
-    regenerate_catalog_tool,
-    generate_book_insights_tool,
-]
+
+def register(mcp: FastMCP) -> None:
+    """Register every library tool with protocol metadata."""
+    mcp.tool(
+        search_catalog,
+        annotations=ToolAnnotations(
+            title="Search Catalog",
+            readOnlyHint=True,  # never mutates state -> clients may skip confirmation
+            idempotentHint=True,
+            openWorldHint=False,  # operates only on this library's data
+        ),
+        icons=[SEARCH_ICON],
+        tags={"catalog"},
+    )
+
+    mcp.tool(
+        checkout_book,
+        annotations=ToolAnnotations(
+            title="Check Out Book",
+            readOnlyHint=False,
+            destructiveHint=False,  # additive: creates a loan, destroys nothing
+            idempotentHint=False,  # same call twice = two loans
+            openWorldHint=False,
+        ),
+        icons=[CARD_ICON],
+        tags={"circulation"},
+    )
+
+    mcp.tool(
+        return_book,
+        annotations=ToolAnnotations(
+            title="Return Book",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        icons=[CARD_ICON],
+        tags={"circulation"},
+    )
+
+    mcp.tool(
+        reserve_book,
+        annotations=ToolAnnotations(
+            title="Reserve Book",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        icons=[CARD_ICON],
+        tags={"circulation"},
+    )
+
+    mcp.tool(
+        renew_membership,
+        annotations=ToolAnnotations(
+            title="Renew Membership",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        icons=[CARD_ICON],
+        tags={"membership", "elicitation-demo"},
+    )
+
+    mcp.tool(
+        bulk_import_books,
+        annotations=ToolAnnotations(
+            title="Bulk Import Books",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        icons=[BOOK_ICON],
+        tags={"catalog", "admin"},
+    )
+
+    mcp.tool(
+        regenerate_catalog,
+        # SEP-1686: task-aware clients may run this in the background and
+        # poll for completion; others get a normal (slow) synchronous call.
+        task=TaskConfig(mode="optional"),
+        annotations=ToolAnnotations(
+            title="Regenerate Catalog",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,  # safe to re-run; rebuilds the same caches
+            openWorldHint=False,
+        ),
+        icons=[MAINTENANCE_ICON],
+        tags={"admin"},
+    )
+
+    mcp.tool(
+        generate_book_insights,
+        annotations=ToolAnnotations(
+            title="Generate Book Insights",
+            readOnlyHint=True,
+            idempotentHint=False,  # sampling output varies run to run
+            openWorldHint=False,
+        ),
+        icons=[SPARKLE_ICON],
+        tags={"ai", "sampling-demo"},
+    )
+
 
 __all__ = [
-    "all_tools",
     "bulk_import_books",
     "checkout_book",
-    "generate_book_insights_tool",
-    "regenerate_catalog_tool",
+    "generate_book_insights",
+    "regenerate_catalog",
+    "register",
+    "renew_membership",
     "reserve_book",
     "return_book",
     "search_catalog",

--- a/virtual-library-mcp/tools/book_insights.py
+++ b/virtual-library-mcp/tools/book_insights.py
@@ -1,95 +1,99 @@
 """
-Book Insights Tool - Educational Demonstration of MCP Sampling
+Book Insights Tool - MCP Sampling in Practice
 
-This tool demonstrates how to integrate MCP sampling into a practical feature.
-It generates AI-powered insights about books in the library catalog, showing
-how sampling can enhance existing functionality with dynamic content.
+Generates AI-powered insights about catalog books by asking the CLIENT's
+LLM to write them (MCP sampling). Demonstrates:
+
+1. ctx.sample() — server-initiated completions with model preferences
+2. Tool-enabled sampling (SEP-1577, MCP 2025-11-25): for similar-book
+   recommendations, the client's LLM is handed a search tool so its
+   suggestions are grounded in what this library actually owns
+3. Graceful fallback when the client doesn't support sampling
 """
 
 import logging
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastmcp import Context
+from fastmcp.exceptions import ToolError
 from pydantic import Field
 
 from database.author_repository import AuthorRepository
-from database.book_repository import BookRepository
+from database.book_repository import BookRepository, BookSearchParams
+from database.repository import PaginationParams
 from database.session import session_scope
 from models.book import Book
-
-# Observability is handled by middleware, not decorators
 from sampling import request_ai_generation
 
 logger = logging.getLogger(__name__)
 
-# Type for different insight types
 InsightType = Literal["summary", "themes", "discussion_questions", "similar_books"]
 
 
-async def generate_book_insights_handler(
-    context: Context,
-    isbn: str = Field(description="ISBN of the book to generate insights for"),
-    insight_type: InsightType = Field(
-        default="summary",
-        description="Type of insight to generate: summary, themes, discussion_questions, or similar_books",
-    ),
-) -> str:
-    """
-    Generate AI-powered insights about a book using MCP sampling.
+def search_library_catalog(genre: str, limit: int = 8) -> list[dict]:
+    """Search this library's catalog for available books in a genre.
 
-    This tool demonstrates:
-    1. Integration with existing database/repository pattern
-    2. Different types of AI-generated content
-    3. Graceful fallback when sampling is unavailable
-    4. Context-aware prompt construction
-
-    The tool will attempt to use sampling if available, but provides
-    meaningful fallback behavior for clients without sampling support.
+    Exposed to the *client's* LLM during tool-enabled sampling so that
+    similar-book recommendations only mention titles we actually hold.
     """
-    # Get the book from the database
     with session_scope() as session:
-        book_repo = BookRepository(session)
-        book_model = book_repo.get_by_isbn(isbn)
+        repo = BookRepository(session)
+        result = repo.search(
+            search_params=BookSearchParams(genre=genre.strip().title(), available_only=False),
+            pagination=PaginationParams(page=1, page_size=max(1, min(limit, 20))),
+        )
+        return [
+            {
+                "title": b.title,
+                "isbn": b.isbn,
+                "genre": b.genre,
+                "year": b.publication_year,
+                "available": b.is_available,
+            }
+            for b in result.items
+        ]
 
-        if not book_model:
-            return f"Error: Book with ISBN {isbn} not found in the library catalog."
 
-        # Get author name using author repository
-        author_repo = AuthorRepository(session)
-        author = author_repo.get_by_id(book_model.author_id)
+async def generate_book_insights(
+    isbn: Annotated[
+        str, Field(description="ISBN-13 of the book to generate insights for", pattern=r"^\d{13}$")
+    ],
+    ctx: Context,
+    insight_type: Annotated[
+        InsightType,
+        Field(
+            description="Kind of insight: summary, themes, discussion_questions, or similar_books"
+        ),
+    ] = "summary",
+) -> str:
+    """Generate AI-powered insights about a book using MCP sampling.
+
+    Falls back to genre-based static content when the connected client
+    doesn't support sampling, so the tool is useful everywhere.
+    """
+    with session_scope() as session:
+        book = BookRepository(session).get_by_isbn(isbn)
+        if not book:
+            raise ToolError(f"Book with ISBN {isbn} not found in the catalog.")
+        author = AuthorRepository(session).get_by_id(book.author_id)
         author_name = author.name if author else "Unknown Author"
 
-    # Check if sampling is available
-    if not context.request_context.session.client_capabilities.sampling:
-        # Fallback behavior when sampling is not available
-        return _generate_fallback_response(book_model, author_name, insight_type)
+    generators = {
+        "summary": _generate_summary,
+        "themes": _generate_themes,
+        "discussion_questions": _generate_discussion_questions,
+        "similar_books": _generate_similar_books,
+    }
+    result = await generators[insight_type](ctx, book, author_name)
 
-    # Generate different prompts based on insight type
-    try:
-        if insight_type == "summary":
-            result = await _generate_summary(context, book_model, author_name)
-        elif insight_type == "themes":
-            result = await _generate_themes(context, book_model, author_name)
-        elif insight_type == "discussion_questions":
-            result = await _generate_discussion_questions(context, book_model, author_name)
-        elif insight_type == "similar_books":
-            result = await _generate_similar_books(context, book_model, author_name)
-        else:
-            result = None
-
-        if result:
-            return f"**AI-Generated {insight_type.replace('_', ' ').title()} for '{book_model.title}'**\n\n{result}"
-        # Sampling failed, use fallback
-        logger.warning(f"Sampling failed for {insight_type}, using fallback")
-        return _generate_fallback_response(book_model, author_name, insight_type)
-
-    except Exception:
-        logger.exception("Error generating insights")
-        return _generate_fallback_response(book_model, author_name, insight_type)
+    if result:
+        title = insight_type.replace("_", " ").title()
+        return f"**AI-Generated {title} for '{book.title}'**\n\n{result}"
+    logger.info("Sampling unavailable for %s; serving fallback content", insight_type)
+    return _generate_fallback_response(book, author_name, insight_type)
 
 
-async def _generate_summary(context, book: Book, author_name: str) -> str | None:
-    """Generate an enhanced book summary using sampling."""
+async def _generate_summary(ctx: Context, book: Book, author_name: str) -> str | None:
     prompt = f"""Create an engaging summary for this library book:
 
 Title: {book.title}
@@ -98,24 +102,21 @@ Genre: {book.genre}
 Published: {book.publication_year}
 Current description: {book.description or "No description available"}
 
-Generate a compelling 2-3 paragraph summary that would help library patrons decide if they want to read this book.
-Focus on the main themes, writing style, and what makes it unique."""
-
-    system_prompt = "You are a knowledgeable librarian creating book summaries. Be informative and engaging without spoilers."
+Generate a compelling 2-3 paragraph summary that would help library patrons
+decide if they want to read this book. Focus on themes, style, and what makes it unique."""
 
     return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
+        ctx,
+        prompt,
+        system_prompt=(
+            "You are a knowledgeable librarian creating book summaries. "
+            "Be informative and engaging without spoilers."
+        ),
         max_tokens=400,
-        temperature=0.7,
-        intelligence_priority=0.8,
-        speed_priority=0.4,
     )
 
 
-async def _generate_themes(context, book: Book, author_name: str) -> str | None:
-    """Generate analysis of book themes using sampling."""
+async def _generate_themes(ctx: Context, book: Book, author_name: str) -> str | None:
     prompt = f"""Analyze the major themes in this book:
 
 Title: {book.title}
@@ -123,78 +124,81 @@ Author: {author_name}
 Genre: {book.genre}
 Description: {book.description or "No description available"}
 
-Identify and explain 3-5 major themes in this book. For each theme, provide a brief explanation of how it's explored in the story."""
-
-    system_prompt = "You are a literature expert analyzing book themes for library patrons. Be insightful but avoid major spoilers."
+Identify and explain 3-5 major themes, each with a brief explanation of how
+the story explores it."""
 
     return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
+        ctx,
+        prompt,
+        system_prompt=(
+            "You are a literature expert analyzing book themes for library patrons. "
+            "Be insightful but avoid major spoilers."
+        ),
         max_tokens=500,
         temperature=0.6,
-        intelligence_priority=0.9,  # High intelligence for literary analysis
-        speed_priority=0.3,
     )
 
 
-async def _generate_discussion_questions(context, book: Book, author_name: str) -> str | None:
-    """Generate book club discussion questions using sampling."""
+async def _generate_discussion_questions(ctx: Context, book: Book, author_name: str) -> str | None:
     prompt = f"""Create thoughtful discussion questions for a book club reading:
 
 Title: {book.title}
 Author: {author_name}
 Genre: {book.genre}
 
-Generate 5-7 open-ended discussion questions that would promote engaging conversation in a book club setting.
-Include questions about themes, characters, and the reader's personal connection to the story."""
-
-    system_prompt = "You are a book club facilitator creating discussion questions. Make them thought-provoking and open to interpretation."
+Generate 5-7 open-ended questions covering themes, characters, and the
+reader's personal connection to the story."""
 
     return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
+        ctx,
+        prompt,
+        system_prompt=(
+            "You are a book club facilitator. Make questions thought-provoking "
+            "and open to interpretation."
+        ),
         max_tokens=600,
-        temperature=0.8,  # More creativity for varied questions
-        intelligence_priority=0.7,
-        speed_priority=0.5,
+        temperature=0.8,
     )
 
 
-async def _generate_similar_books(context, book: Book, author_name: str) -> str | None:
-    """Generate recommendations for similar books using sampling."""
-    prompt = f"""Recommend books similar to:
+async def _generate_similar_books(ctx: Context, book: Book, author_name: str) -> str | None:
+    """Tool-enabled sampling (SEP-1577): the client's LLM can call our
+    search_library_catalog() tool mid-completion, so every recommendation
+    can cite real holdings and availability."""
+    prompt = f"""Recommend books from THIS library similar to:
 
 Title: {book.title}
 Author: {author_name}
 Genre: {book.genre}
 Description: {book.description or "No description available"}
 
-Suggest 4-5 books that readers who enjoyed this book might also like.
-For each recommendation, explain what makes it similar (themes, style, genre) and what makes it unique."""
+Use the search_library_catalog tool to check what the library holds in
+relevant genres, then suggest 3-5 of those titles. For each, explain what
+makes it similar and note whether it is currently available."""
 
-    system_prompt = "You are a library recommendation expert. Focus on books that share themes or style while offering something new."
-
-    return await request_ai_generation(
-        context=context,
-        prompt=prompt,
-        system_prompt=system_prompt,
-        max_tokens=700,
-        temperature=0.8,
-        intelligence_priority=0.7,
-        speed_priority=0.6,  # Faster for interactive recommendations
-    )
+    try:
+        result = await ctx.sample(
+            messages=prompt,
+            system_prompt=(
+                "You are a library recommendation expert. Ground every "
+                "recommendation in actual catalog holdings via the provided tool."
+            ),
+            max_tokens=700,
+            temperature=0.8,
+            tools=[search_library_catalog],
+        )
+    except Exception as e:
+        logger.info("Tool-enabled sampling unavailable: %s", e)
+        return None
+    return result.text or None
 
 
 def _generate_fallback_response(book: Book, author_name: str, insight_type: InsightType) -> str:
-    """
-    Generate a meaningful response when sampling is not available.
-
-    This demonstrates how to gracefully degrade functionality while
-    still providing value to the user.
-    """
-    base_info = f"**Book Information**\n\nTitle: {book.title}\nAuthor: {author_name}\nGenre: {book.genre}\nYear: {book.publication_year}\n\n"
+    """Meaningful degradation when the client has no sampling support."""
+    base_info = (
+        f"**Book Information**\n\nTitle: {book.title}\nAuthor: {author_name}\n"
+        f"Genre: {book.genre}\nYear: {book.publication_year}\n\n"
+    )
 
     if insight_type == "summary":
         return base_info + (
@@ -205,7 +209,6 @@ def _generate_fallback_response(book: Book, author_name: str, insight_type: Insi
     if insight_type == "themes":
         fallback_themes = {
             "Fiction": "Common themes might include: human nature, relationships, conflict, and personal growth.",
-            "Non-Fiction": "Key topics might include: main arguments, supporting evidence, and practical applications.",
             "Mystery": "Typical themes include: justice, deception, truth, and moral ambiguity.",
             "Science Fiction": "Common themes: technology's impact, human identity, social commentary, and future possibilities.",
             "Fantasy": "Often explores: good vs evil, power and corruption, coming of age, and destiny.",
@@ -213,7 +216,8 @@ def _generate_fallback_response(book: Book, author_name: str, insight_type: Insi
         genre_themes = fallback_themes.get(book.genre, "Themes vary by genre and author style.")
         return (
             base_info
-            + f"**Genre-Typical Themes**\n\n{genre_themes}\n\n*Note: AI-generated theme analysis requires a client with sampling support.*"
+            + f"**Genre-Typical Themes**\n\n{genre_themes}\n\n"
+            + "*Note: AI-generated theme analysis requires a client with sampling support.*"
         )
 
     if insight_type == "discussion_questions":
@@ -230,30 +234,14 @@ def _generate_fallback_response(book: Book, author_name: str, insight_type: Insi
 *Note: AI-generated discussion questions tailored to this specific book require a client with sampling support.*"""
         )
 
-    if insight_type == "similar_books":
-        return (
-            base_info
-            + f"""**Finding Similar Books**
+    return (
+        base_info
+        + f"""**Finding Similar Books**
 
 To find books similar to this one, consider:
 - Other books by {author_name}
 - Other {book.genre} books in our catalog
-- Books from the same time period ({book.publication_year}s)
-- Books with similar themes or settings
+- Books from the same era ({book.publication_year}s)
 
 *Note: AI-generated personalized recommendations require a client with sampling support.*"""
-        )
-
-    return base_info + "Invalid insight type requested."
-
-
-# Export as dictionary for server registration
-generate_book_insights_tool = {
-    "name": "generate_book_insights",
-    "description": (
-        "Generate AI-powered insights about a book including summaries, themes, "
-        "discussion questions, or similar book recommendations. Demonstrates MCP "
-        "sampling integration for dynamic content generation."
-    ),
-    "handler": generate_book_insights_handler,
-}
+    )

--- a/virtual-library-mcp/tools/bulk_import.py
+++ b/virtual-library-mcp/tools/bulk_import.py
@@ -2,6 +2,11 @@
 
 This module demonstrates MCP progress notifications by providing real-time
 updates during large-scale import operations.
+
+Security note: imports are confined to the server's data/ directory. A
+remote MCP client must never be able to point a file-reading tool at an
+arbitrary filesystem path (path traversal), so every requested path is
+resolved and checked against the allowed root before opening.
 """
 
 import csv
@@ -9,20 +14,42 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 import anyio
 from fastmcp import Context
-from pydantic import BaseModel, Field
+from fastmcp.exceptions import ToolError
+from pydantic import Field
 from sqlalchemy.exc import IntegrityError
 
 from database.schema import Author as AuthorDB
 from database.schema import Book as BookDB
 from database.session import session_scope
 
-# Observability is handled by middleware, not decorators
-
 logger = logging.getLogger(__name__)
+
+# Only files under the project's data/ directory may be imported.
+ALLOWED_IMPORT_ROOT = (Path(__file__).parent.parent / "data").resolve()
+
+
+def _confine_to_import_root(file_path: str) -> Path:
+    """Resolve a user-supplied path and require it to live under data/.
+
+    Rejects absolute paths outside the root and ../ traversal. Relative
+    paths are interpreted relative to the import root for convenience.
+    """
+    candidate = Path(file_path)
+    resolved = (
+        candidate.resolve()
+        if candidate.is_absolute()
+        else (ALLOWED_IMPORT_ROOT / candidate).resolve()
+    )
+    if not resolved.is_relative_to(ALLOWED_IMPORT_ROOT):
+        raise ToolError(
+            f"Import files must live under the server's data directory "
+            f"({ALLOWED_IMPORT_ROOT}). Got: {file_path}"
+        )
+    return resolved
 
 
 def _format_eta(seconds: float) -> str:
@@ -38,47 +65,35 @@ def _format_eta(seconds: float) -> str:
     return f"{hours}h {minutes}m"
 
 
-class BulkImportInput(BaseModel):
-    """Input schema for the bulk_import_books tool."""
-
-    file_path: str = Field(
-        description="Path to the CSV or JSON file containing books to import",
-        min_length=1,
-        examples=["/tmp/books.csv", "/data/import/catalog.json"],
-    )
-
-    batch_size: int = Field(
-        default=50, description="Number of books to process in each batch", ge=1, le=1000
-    )
-
-
-async def import_books_from_file(
-    file_path: str, ctx: Context, batch_size: int = 50
+async def bulk_import_books(
+    file_path: Annotated[
+        str,
+        Field(
+            description=(
+                "Path to a CSV or JSON file under the server's data/ directory, "
+                "e.g. 'samples/books_sample.csv'"
+            ),
+            min_length=1,
+        ),
+    ],
+    ctx: Context,
+    batch_size: Annotated[int, Field(description="Books to process per batch", ge=1, le=1000)] = 50,
 ) -> dict[str, Any]:
-    """Import books from a CSV or JSON file with progress reporting.
+    """Import books in bulk from a CSV or JSON file, with live progress.
 
-    Supports CSV files with headers:
-    - isbn, title, author_name, genre, publication_year, available_copies
-
-    Or JSON files with an array of book objects.
-
-    Args:
-        file_path: Path to the import file
-        batch_size: Number of books to process in each batch
-        ctx: MCP context for progress reporting
-
-    Returns:
-        Import summary with counts and any errors
+    CSV headers: isbn, title, author_name, genre, publication_year,
+    available_copies. JSON: an array of objects with the same fields.
+    Progress notifications stream batch-by-batch with an ETA.
     """
-    # Validate file exists and determine type.
+    path = _confine_to_import_root(file_path)
+
     # anyio.Path performs the stat in a worker thread, keeping the event loop free.
-    path = Path(file_path)
     if not await anyio.Path(path).exists():
-        raise FileNotFoundError(f"Import file not found: {file_path}")
+        raise ToolError(f"Import file not found: {file_path}")
 
     file_type = path.suffix.lower()
     if file_type not in [".csv", ".json"]:
-        raise ValueError(f"Unsupported file type: {file_type}. Use .csv or .json")
+        raise ToolError(f"Unsupported file type: {file_type}. Use .csv or .json")
 
     await ctx.info(f"Starting import from {path.name}")
 
@@ -123,8 +138,10 @@ async def import_books_from_file(
                 )
 
                 try:
-                    # Validate and create book
-                    _create_book_in_db(session, book_data)
+                    # Each book gets its own SAVEPOINT so one bad row
+                    # (e.g. duplicate ISBN) can't poison the whole batch.
+                    with session.begin_nested():
+                        _create_book_in_db(session, book_data)
                     successful += 1
 
                 except ValueError as e:
@@ -138,14 +155,12 @@ async def import_books_from_file(
                     error_msg = f"Book {current_book}: Database error - Book may already exist"
                     errors.append(error_msg)
                     await ctx.warning(error_msg)
-                    session.rollback()
 
                 except Exception as e:
                     failed += 1
                     error_msg = f"Book {current_book}: Unexpected error - {e!s}"
                     errors.append(error_msg)
                     await ctx.error(error_msg)
-                    session.rollback()
 
             # Commit batch
             try:
@@ -265,76 +280,3 @@ def _create_book_in_db(session, data: dict[str, Any]) -> None:
         description=data.get("description"),
     )
     session.add(book)
-
-
-async def bulk_import_books_handler(arguments: dict[str, Any], ctx: Context) -> dict[str, Any]:
-    """Handler for the bulk_import_books tool.
-
-    Accepts file path and batch size, performs import with progress notifications.
-    """
-    try:
-        # Validate input
-        try:
-            params = BulkImportInput.model_validate(arguments)
-        except Exception as e:
-            logger.warning("Invalid import parameters: %s", e)
-            return {
-                "isError": True,
-                "content": [{"type": "text", "text": f"Invalid import parameters: {e}"}],
-            }
-
-        # Execute import
-        try:
-            result = await import_books_from_file(
-                file_path=params.file_path, ctx=ctx, batch_size=params.batch_size
-            )
-
-            # Format successful response
-            summary_text = (
-                f"Import completed: {result['successful_imports']}/{result['total_books']} "
-                f"books imported successfully ({result['success_rate']})"
-            )
-
-            if result["failed_imports"] > 0:
-                summary_text += f"\n{result['failed_imports']} imports failed."
-                if result["errors"]:
-                    summary_text += "\nFirst few errors:\n" + "\n".join(result["errors"][:5])
-
-            return {"content": [{"type": "text", "text": summary_text}], "data": result}
-
-        except FileNotFoundError as e:
-            return {
-                "isError": True,
-                "content": [{"type": "text", "text": str(e)}],
-            }
-        except ValueError as e:
-            return {
-                "isError": True,
-                "content": [{"type": "text", "text": str(e)}],
-            }
-        except Exception as e:
-            logger.exception("Import execution failed")
-            return {
-                "isError": True,
-                "content": [{"type": "text", "text": f"Import failed: {e!s}"}],
-            }
-
-    except Exception as e:
-        logger.exception("Unexpected error in bulk_import_books tool")
-        return {
-            "isError": True,
-            "content": [{"type": "text", "text": f"An unexpected error occurred: {e!s}"}],
-        }
-
-
-bulk_import_books = {
-    "name": "bulk_import_books",
-    "description": (
-        "Import books from a CSV or JSON file with real-time progress updates. "
-        "CSV files should have headers: isbn, title, author_name, genre, "
-        "publication_year, available_copies. JSON files should contain an array "
-        "of book objects. Validates data, processes in batches, and reports errors."
-    ),
-    "inputSchema": BulkImportInput.model_json_schema(),
-    "handler": bulk_import_books_handler,
-}

--- a/virtual-library-mcp/tools/catalog_maintenance.py
+++ b/virtual-library-mcp/tools/catalog_maintenance.py
@@ -9,10 +9,12 @@ import logging
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.tools import ToolResult
 from sqlalchemy import func
 
 from database.circulation_repository import CirculationRepository
 from database.patron_repository import PatronRepository
+from database.repository import PaginationParams
 from database.schema import Author as AuthorDB
 from database.schema import Book as BookDB
 from database.schema import CheckoutRecord
@@ -23,44 +25,52 @@ from database.session import session_scope
 logger = logging.getLogger(__name__)
 
 
-async def regenerate_catalog(ctx: Context) -> dict[str, Any]:
-    """Regenerate catalog indexes and statistics with progress reporting.
+# The resource taken offline while its cache rebuilds (maintenance mode).
+RECOMMENDATIONS_RESOURCE = "Personalized Book Recommendations"
 
-    This simulates a multi-stage maintenance operation:
-    1. Verify data integrity (0-20%)
-    2. Rebuild search indexes (20-50%)
-    3. Update circulation statistics (50-80%)
-    4. Generate recommendations cache (80-100%)
 
-    Args:
-        ctx: MCP context for progress reporting
+async def regenerate_catalog(ctx: Context) -> ToolResult:
+    """Perform full catalog maintenance with live progress reporting.
 
-    Returns:
-        Maintenance summary with statistics
+    Four stages, each reporting progress: data integrity (0-20%), search
+    indexes (20-50%), circulation statistics (50-80%), and the
+    recommendations cache (80-100%).
+
+    MCP concepts on display:
+    - Progress notifications across a long-running operation
+    - notifications/resources/list_changed: the recommendations resource is
+      disabled during the rebuild and re-enabled after, and FastMCP
+      notifies connected clients of both visibility changes automatically
+    - ToolResult: human-readable summary AND machine-readable structure
+    - Background tasks (SEP-1686): registered with task support, so task-aware
+      clients can run it asynchronously and poll for the result
     """
     await ctx.info("Starting catalog regeneration")
 
-    # Stage 1: Verify data integrity (0-20%)
-    await ctx.info("Stage 1: Verifying data integrity")
-    integrity_results = await _verify_data_integrity(ctx, 0, 20)
+    # MAINTENANCE MODE: hide the recommendations template from this session
+    # while its cache is being rebuilt. ctx.disable_components() and the
+    # closing reset_visibility() each push a resources/list_changed
+    # notification to the client, demonstrating live visibility changes.
+    await ctx.disable_components(names={RECOMMENDATIONS_RESOURCE}, components={"template"})
+    try:
+        await ctx.info("Stage 1: Verifying data integrity")
+        integrity_results = await _verify_data_integrity(ctx, 0, 20)
 
-    # Stage 2: Rebuild search indexes (20-50%)
-    await ctx.info("Stage 2: Rebuilding search indexes")
-    index_results = await _rebuild_search_indexes(ctx, 20, 50)
+        await ctx.info("Stage 2: Rebuilding search indexes")
+        index_results = await _rebuild_search_indexes(ctx, 20, 50)
 
-    # Stage 3: Update circulation statistics (50-80%)
-    await ctx.info("Stage 3: Updating circulation statistics")
-    stats_results = await _update_circulation_stats(ctx, 50, 80)
+        await ctx.info("Stage 3: Updating circulation statistics")
+        stats_results = await _update_circulation_stats(ctx, 50, 80)
 
-    # Stage 4: Generate recommendations cache (80-100%)
-    await ctx.info("Stage 4: Generating recommendations cache")
-    cache_results = await _generate_recommendations_cache(ctx, 80, 100)
+        await ctx.info("Stage 4: Generating recommendations cache")
+        cache_results = await _generate_recommendations_cache(ctx, 80, 100)
+    finally:
+        await ctx.reset_visibility()
 
-    # Final completion
     await ctx.report_progress(progress=100, total=100, message="Catalog regeneration complete")
     await ctx.info("Catalog regeneration completed successfully")
 
-    return {
+    result = {
         "status": "completed",
         "integrity_check": integrity_results,
         "search_indexes": index_results,
@@ -68,6 +78,30 @@ async def regenerate_catalog(ctx: Context) -> dict[str, Any]:
         "recommendations_cache": cache_results,
         "message": "Catalog regeneration completed successfully",
     }
+    return ToolResult(content=_format_summary(result), structured_content=result)
+
+
+def _format_summary(result: dict[str, Any]) -> str:
+    """Human-readable maintenance report for the text content block."""
+    lines = [
+        "Catalog regeneration completed successfully!",
+        "",
+        f"- Data integrity: {result['integrity_check']['books_checked']} books checked",
+        f"- Search indexes: {result['search_indexes']['books_indexed']} books, "
+        f"{result['search_indexes']['authors_indexed']} authors, "
+        f"{result['search_indexes']['genres_indexed']} genres indexed",
+        f"- Circulation: {result['circulation_stats']['active_loans']} active loans, "
+        f"{result['circulation_stats']['overdue_loans']} overdue",
+        f"- Recommendations: {result['recommendations_cache']['patrons_processed']} patrons, "
+        f"{result['recommendations_cache']['recommendations_generated']} recommendations",
+    ]
+    if result["integrity_check"]["orphaned_books"]:
+        lines.append(f"- WARNING: {result['integrity_check']['orphaned_books']} orphaned books")
+    if result["integrity_check"]["invalid_circulations"]:
+        lines.append(
+            f"- WARNING: {result['integrity_check']['invalid_circulations']} invalid circulations"
+        )
+    return "\n".join(lines)
 
 
 async def _verify_data_integrity(
@@ -198,21 +232,19 @@ async def _update_circulation_stats(
     with session_scope() as session:
         repo = CirculationRepository(session)
 
-        # Count active loans
+        # Count active and overdue loans from circulation statistics
         await ctx.report_progress(
             progress=start_progress + 5, total=100, message="Counting active loans"
         )
 
-        active_loans = repo.get_active_loans()
-        results["active_loans"] = len(active_loans)
+        stats = repo.get_circulation_stats()
+        results["active_loans"] = stats.active_checkouts
 
-        # Count overdue loans
         await ctx.report_progress(
             progress=start_progress + 10, total=100, message="Checking for overdue loans"
         )
 
-        overdue_loans = repo.get_overdue_loans()
-        results["overdue_loans"] = len(overdue_loans)
+        results["overdue_loans"] = stats.overdue_checkouts
 
         if results["overdue_loans"] > 0:
             await ctx.warning(f"Found {results['overdue_loans']} overdue loans")
@@ -250,8 +282,8 @@ async def _generate_recommendations_cache(
     with session_scope() as session:
         patron_repo = PatronRepository(session)
 
-        # Get all active patrons
-        all_patrons = patron_repo.list(limit=1000)
+        # Get all patrons (paged API; one page is plenty for this library)
+        all_patrons = patron_repo.get_all(pagination=PaginationParams(page=1, page_size=100))
         total_patrons = len(all_patrons.items)
 
         # Process patrons in batches
@@ -291,66 +323,3 @@ async def _generate_recommendations_cache(
         )
 
     return results
-
-
-async def regenerate_catalog_handler(_: dict[str, Any], ctx: Context) -> dict[str, Any]:
-    """Handler for the regenerate_catalog tool.
-
-    No input parameters needed - performs full catalog maintenance.
-    """
-    try:
-        # Execute catalog regeneration
-        result = await regenerate_catalog(ctx)
-
-        # Format response
-        summary_lines = [
-            "Catalog regeneration completed successfully!",
-            "",
-            f"✓ Data Integrity: {result['integrity_check']['books_checked']} books checked",
-        ]
-
-        if result["integrity_check"]["orphaned_books"] > 0:
-            summary_lines.append(
-                f"  ⚠ {result['integrity_check']['orphaned_books']} orphaned books found"
-            )
-        if result["integrity_check"]["invalid_circulations"] > 0:
-            summary_lines.append(
-                f"  ⚠ {result['integrity_check']['invalid_circulations']} invalid circulations found"
-            )
-
-        summary_lines.extend(
-            [
-                "",
-                f"✓ Search Indexes: {result['search_indexes']['books_indexed']} books, "
-                f"{result['search_indexes']['authors_indexed']} authors, "
-                f"{result['search_indexes']['genres_indexed']} genres indexed",
-                "",
-                f"✓ Circulation Stats: {result['circulation_stats']['active_loans']} active loans, "
-                f"{result['circulation_stats']['overdue_loans']} overdue",
-                "",
-                f"✓ Recommendations: Generated for {result['recommendations_cache']['patrons_processed']} patrons "
-                f"({result['recommendations_cache']['recommendations_generated']} total recommendations)",
-            ]
-        )
-
-        return {"content": [{"type": "text", "text": "\n".join(summary_lines)}], "data": result}
-
-    except Exception as e:
-        logger.exception("Unexpected error in regenerate_catalog tool")
-        return {
-            "isError": True,
-            "content": [{"type": "text", "text": f"Catalog regeneration failed: {e!s}"}],
-        }
-
-
-regenerate_catalog_tool = {
-    "name": "regenerate_catalog",
-    "description": (
-        "Perform comprehensive catalog maintenance with progress tracking. "
-        "This includes: data integrity checks, search index rebuilding, "
-        "circulation statistics updates, and recommendation cache generation. "
-        "Progress is reported in real-time through multiple stages."
-    ),
-    "inputSchema": {"type": "object", "properties": {}, "required": []},
-    "handler": regenerate_catalog_handler,
-}

--- a/virtual-library-mcp/tools/circulation.py
+++ b/virtual-library-mcp/tools/circulation.py
@@ -1,19 +1,26 @@
 """Circulation Tools - Library Transaction Management
 
 Modifies library state through checkout, return, and reservation operations.
-Clients use these tools to manage book loans and patron interactions.
 
-Tools:
-- checkout_book: Loan a book to a patron
-- return_book: Process book returns with fines
-- reserve_book: Queue management for unavailable books
+MCP concepts demonstrated:
+- Typed parameters -> rich input schemas (the LLM sees real field names,
+  patterns, and constraints instead of an opaque object).
+- Structured output via Pydantic return models (outputSchema +
+  structuredContent on every call).
+- Elicitation (MCP 2025-11-25): checkout_book pauses mid-execution to ask
+  the user for confirmation when the patron carries outstanding fines —
+  a server-initiated request that flows through the client to a human.
+- Tool execution errors (SEP-1303): business-rule violations raise
+  ToolError so the model can recover, instead of opaque protocol errors.
 """
 
 import logging
 from datetime import date, datetime, timedelta
-from typing import Any
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
 
 from database.circulation_repository import (
     CheckoutCreateSchema,
@@ -21,550 +28,314 @@ from database.circulation_repository import (
     ReservationCreateSchema,
     ReturnProcessSchema,
 )
+from database.patron_repository import PatronRepository
 from database.repository import NotFoundError, RepositoryException
 from database.session import get_session
 
-# Observability is handled by middleware, not decorators
-
 logger = logging.getLogger(__name__)
 
-
-def _format_error_response(error_type: str, details: str) -> dict[str, Any]:
-    """Format error responses consistently across all tools."""
-    return {"isError": True, "content": [{"type": "text", "text": f"{error_type}: {details}"}]}
+PATRON_ID_FIELD = Field(
+    description="Patron identifier, e.g. 'patron_00042'",
+    pattern=r"^patron_[a-zA-Z0-9_]{5,}$",
+)
+ISBN_FIELD = Field(description="ISBN-13 of the book (13 digits)", pattern=r"^\d{13}$")
 
 
 def _log_operation(operation: str, **kwargs) -> None:
-    """Log operation details for audit trail."""
+    """Audit-trail logging for every state-changing operation."""
     logger.info(
         "Operation: %s | Details: %s", operation, " | ".join(f"{k}={v}" for k, v in kwargs.items())
     )
 
 
-class CheckoutBookInput(BaseModel):
-    """Input schema for book checkout operations."""
-
-    patron_id: str = Field(
-        ...,
-        description="Unique identifier of the patron borrowing the book",
-        pattern=r"^patron_[a-zA-Z0-9_]{5,}$",
-        examples=["patron_smith001", "patron_doe_jane", "patron_wilson_robert"],
-    )
-
-    book_isbn: str = Field(
-        ...,
-        description="ISBN-13 of the book to checkout",
-        pattern=r"^\d{13}$",
-        examples=["9780134685479", "9780061120084", "9780062316097"],
-    )
-
-    due_date: date | None = Field(
-        default=None,
-        description="Optional custom due date. If not provided, uses standard 14-day loan period",
-        examples=["2024-02-15", "2024-03-01"],
-    )
-
-    notes: str | None = Field(
-        default=None,
-        description="Optional notes about this checkout (e.g., 'Book club selection')",
-        max_length=500,
-        examples=["Book club reading", "Research for thesis", "Recommended by librarian"],
-    )
-
-    @field_validator("due_date")
-    @classmethod
-    def validate_due_date(cls, v: date | None) -> date | None:
-        """Ensure due date is not in the past."""
-        if v is not None and v < datetime.now().date():
-            raise ValueError("Due date cannot be in the past")
-        return v
+# ---------------------------------------------------------------------------
+# Structured output models — these become each tool's outputSchema
+# ---------------------------------------------------------------------------
 
 
-async def checkout_book_handler(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Process book checkout request.
+class CheckoutResult(BaseModel):
+    """Confirmation details for a successful checkout."""
 
-    Validates patron eligibility, book availability, and creates loan record.
-    Returns checkout confirmation with due date or error details.
+    checkout_id: str
+    patron_id: str
+    book_isbn: str
+    checkout_date: str
+    due_date: str
+    status: str
+    loan_period_days: int
+    message: str
 
-    Client calls: tool.call("checkout_book", {"patron_id": "...", "book_isbn": "..."})
+
+class ReturnResult(BaseModel):
+    """Confirmation details for a processed return, including fines."""
+
+    return_id: str
+    checkout_id: str
+    book_isbn: str
+    return_date: str
+    condition: str
+    late_days: int
+    fine_assessed: float
+    fine_outstanding: float
+    message: str
+
+
+class ReservationResult(BaseModel):
+    """Confirmation details for a reservation, including queue status."""
+
+    reservation_id: str
+    patron_id: str
+    book_isbn: str
+    reservation_date: str
+    expiration_date: str
+    status: str
+    queue_position: int
+    estimated_wait_days: int | None
+    total_in_queue: int
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# checkout_book — demonstrates elicitation (server-initiated user input)
+# ---------------------------------------------------------------------------
+
+
+async def checkout_book(
+    patron_id: Annotated[str, PATRON_ID_FIELD],
+    book_isbn: Annotated[str, ISBN_FIELD],
+    ctx: Context,
+    due_date: Annotated[
+        date | None,
+        Field(description="Custom due date (defaults to a 14-day loan)"),
+    ] = None,
+    notes: Annotated[
+        str | None,
+        Field(description="Optional notes, e.g. 'Book club selection'", max_length=500),
+    ] = None,
+) -> CheckoutResult:
+    """Check out a book to a patron.
+
+    Validates patron eligibility and book availability, creates the loan
+    record, and updates availability. If the patron has outstanding fines,
+    the user is asked to confirm before proceeding (elicitation).
     """
-    try:
+    if due_date is not None and due_date < datetime.now().date():
+        raise ToolError("Due date cannot be in the past.")
+
+    _log_operation("checkout_book_start", patron_id=patron_id, book_isbn=book_isbn)
+
+    # ELICITATION (MCP 2025-11-25): when a patron carries fines but is still
+    # allowed to borrow, defer the judgment call to the human. The request
+    # travels server -> client -> user and execution pauses for the answer.
+    with get_session() as session:
+        patron = PatronRepository(session).get_by_id(patron_id)
+    if patron is not None and 0 < patron.outstanding_fines <= 10.0:
         try:
-            params = CheckoutBookInput.model_validate(arguments)
-        except Exception as e:
-            logger.warning("Invalid checkout parameters: %s", e)
-            return _format_error_response("Invalid parameters", str(e))
-
-        _log_operation(
-            "checkout_book_start",
-            patron_id=params.patron_id,
-            book_isbn=params.book_isbn,
-            due_date=params.due_date,
-            has_notes=bool(params.notes),
-        )
-
-        with get_session() as session:
-            try:
-                repo = CirculationRepository(session)
-                checkout_data = CheckoutCreateSchema(
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    due_date=params.due_date,
-                    notes=params.notes,
-                )
-
-                checkout = repo.checkout_book(checkout_data)
-
-            except NotFoundError as e:
-                logger.info("Checkout failed - entity not found: %s", e)
-                _log_operation(
-                    "checkout_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="not_found",
-                    error_details=str(e),
-                )
-                return _format_error_response("Not found", str(e))
-
-            except RepositoryException as e:
-                # MCP ERROR PATTERN: Business rule violation
-                # Return specific error for checkout restrictions
-                logger.info("Checkout failed - business rule: %s", e)
-                _log_operation(
-                    "checkout_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="business_rule",
-                    error_details=str(e),
-                )
-                return _format_error_response("Operation failed", str(e))
-
-            except Exception as e:
-                # MCP ERROR PATTERN: Unexpected database error
-                logger.exception("Checkout database error")
-                _log_operation(
-                    "checkout_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="database_error",
-                    error_details=str(e),
-                )
-                return _format_error_response("Database error", f"Checkout failed: {e!s}")
-
-        # STEP 3: Format successful response
-        # MCP RESPONSE FORMAT: Tools return structured content
-        # The response includes both human-readable text and structured data
-        message = (
-            f"Successfully checked out book '{checkout.book_isbn}' "
-            f"to patron '{checkout.patron_id}'. "
-            f"Due date: {checkout.due_date.strftime('%B %d, %Y')}"
-        )
-
-        if checkout.loan_period_days == 14:
-            message += " (standard 14-day loan)"
-        else:
-            message += f" ({checkout.loan_period_days}-day loan)"
-
-        # Log successful operation
-        _log_operation(
-            "checkout_book_success",
-            checkout_id=checkout.id,
-            patron_id=checkout.patron_id,
-            book_isbn=checkout.book_isbn,
-            due_date=checkout.due_date.isoformat(),
-            loan_period_days=checkout.loan_period_days,
-        )
-
-        # Return MCP-compliant response
-        return {
-            "content": [{"type": "text", "text": message}],
-            # Include structured data for client processing
-            # WHY: LLMs can use this data for follow-up actions
-            "data": {
-                "checkout": {
-                    "id": checkout.id,
-                    "patron_id": checkout.patron_id,
-                    "book_isbn": checkout.book_isbn,
-                    "checkout_date": checkout.checkout_date.isoformat(),
-                    "due_date": checkout.due_date.isoformat(),
-                    "status": checkout.status,
-                    "renewal_count": checkout.renewal_count,
-                    "loan_period_days": checkout.loan_period_days,
-                }
-            },
-        }
-
-    except Exception as e:
-        # MCP ERROR PATTERN: Catch-all for unexpected errors
-        # This ensures the tool never crashes the server
-        logger.exception("Unexpected error in checkout_book tool")
-        return _format_error_response("Unexpected error", str(e))
-
-
-class ReturnBookInput(BaseModel):
-    """Input schema for book return operations."""
-
-    checkout_id: str = Field(
-        ...,
-        description="ID of the checkout record to return",
-        pattern=r"^checkout_[a-zA-Z0-9]+$",
-        examples=["checkout_202312150001", "checkout_202403201234"],
-    )
-
-    condition: str = Field(
-        default="good",
-        description="Condition of the returned book",
-        pattern=r"^(excellent|good|fair|damaged|lost)$",
-        examples=["excellent", "good", "fair", "damaged", "lost"],
-    )
-
-    notes: str | None = Field(
-        default=None,
-        description="Optional notes about the return (e.g., damage details)",
-        max_length=500,
-        examples=[
-            "Minor water damage on cover",
-            "Missing dust jacket",
-            "Highlighted text on pages 45-67",
-        ],
-    )
-
-    rating: int | None = Field(
-        default=None,
-        description="Optional patron rating of the book (1-5 stars)",
-        ge=1,
-        le=5,
-        examples=[1, 2, 3, 4, 5],
-    )
-
-    review: str | None = Field(
-        default=None,
-        description="Optional patron review of the book",
-        max_length=1000,
-        examples=["Great read, highly recommend!", "Not what I expected but still enjoyable"],
-    )
-
-
-async def return_book_handler(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Process book return request.
-
-    Calculates late fines, updates book availability, and records condition.
-    Returns confirmation with fine details if applicable.
-
-    Client calls: tool.call("return_book", {"checkout_id": "..."})
-    """
-    try:
-        # Validate input
-        try:
-            params = ReturnBookInput.model_validate(arguments)
-        except Exception as e:
-            logger.warning("Invalid return parameters: %s", e)
-            return _format_error_response("Invalid parameters", str(e))
-
-        # Log operation start
-        _log_operation(
-            "return_book_start",
-            checkout_id=params.checkout_id,
-            condition=params.condition,
-            has_notes=bool(params.notes),
-            has_rating=bool(params.rating),
-            has_review=bool(params.review),
-        )
-
-        # Execute return
-        with get_session() as session:
-            try:
-                repo = CirculationRepository(session)
-
-                # Convert to repository schema
-                return_data = ReturnProcessSchema(
-                    checkout_id=params.checkout_id,
-                    condition=params.condition,
-                    notes=params.notes,
-                    processed_by="mcp_tool",  # Track that this was an MCP operation
-                )
-
-                # Process return
-                return_record, _ = repo.return_book(return_data)
-
-                # If rating/review provided, we could store it
-                # (future enhancement: add review system)
-                if params.rating or params.review:
-                    logger.info(
-                        "Book review received - Rating: %s, Review: %s",
-                        params.rating,
-                        params.review[:100] if params.review else None,
-                    )
-
-            except NotFoundError as e:
-                logger.info("Return failed - checkout not found: %s", e)
-                _log_operation(
-                    "return_book_failed",
-                    checkout_id=params.checkout_id,
-                    error_type="not_found",
-                    error_details=str(e),
-                )
-                return _format_error_response("Not found", str(e))
-
-            except RepositoryException as e:
-                logger.info("Return failed - business rule: %s", e)
-                _log_operation(
-                    "return_book_failed",
-                    checkout_id=params.checkout_id,
-                    error_type="business_rule",
-                    error_details=str(e),
-                )
-                return _format_error_response("Operation failed", str(e))
-
-            except Exception as e:
-                logger.exception("Return database error")
-                _log_operation(
-                    "return_book_failed",
-                    checkout_id=params.checkout_id,
-                    error_type="database_error",
-                    error_details=str(e),
-                )
-                return _format_error_response("Database error", f"Return failed: {e!s}")
-
-        # Format response with fine information
-        message = f"Successfully returned book '{return_record.book_isbn}'."
-
-        if return_record.late_days > 0:
-            message += (
-                f" Book was {return_record.late_days} days late. "
-                f"Fine assessed: ${return_record.fine_assessed:.2f}"
+            answer = await ctx.elicit(
+                f"{patron.name} has ${patron.outstanding_fines:.2f} in outstanding "
+                "fines. Proceed with this checkout anyway?",
+                response_type=None,  # approval-only: accept / decline / cancel
             )
+        except Exception:  # client doesn't support elicitation — proceed
+            logger.info("Client lacks elicitation support; proceeding without confirmation")
         else:
-            message += " Returned on time - no fines."
+            if answer.action != "accept":
+                _log_operation("checkout_book_declined", patron_id=patron_id, action=answer.action)
+                raise ToolError(
+                    "Checkout cancelled: the librarian declined to proceed while "
+                    f"the patron has ${patron.outstanding_fines:.2f} in fines."
+                )
 
-        if params.condition != "good":
-            message += f" Book condition noted as: {params.condition}"
-
-        # Log successful operation
-        _log_operation(
-            "return_book_success",
-            return_id=return_record.id,
-            checkout_id=return_record.checkout_id,
-            book_isbn=return_record.book_isbn,
-            condition=return_record.condition,
-            late_days=return_record.late_days,
-            fine_assessed=return_record.fine_assessed,
-        )
-
-        return {
-            "content": [{"type": "text", "text": message}],
-            "data": {
-                "return": {
-                    "id": return_record.id,
-                    "checkout_id": return_record.checkout_id,
-                    "return_date": return_record.return_date.isoformat(),
-                    "condition": return_record.condition,
-                    "late_days": return_record.late_days,
-                    "fine_assessed": return_record.fine_assessed,
-                    "fine_paid": return_record.fine_paid,
-                    "fine_outstanding": return_record.fine_outstanding,
-                }
-            },
-        }
-
-    except Exception as e:
-        logger.exception("Unexpected error in return_book tool")
-        return _format_error_response("Unexpected error", str(e))
-
-
-class ReserveBookInput(BaseModel):
-    """Input schema for book reservation operations."""
-
-    patron_id: str = Field(
-        ...,
-        description="Unique identifier of the patron making the reservation",
-        pattern=r"^patron_[a-zA-Z0-9_]{5,}$",
-        examples=["patron_smith001", "patron_doe_jane"],
-    )
-
-    book_isbn: str = Field(
-        ...,
-        description="ISBN-13 of the book to reserve",
-        pattern=r"^\d{13}$",
-        examples=["9780134685479", "9780061120084"],
-    )
-
-    expiration_date: date | None = Field(
-        default=None,
-        description="Optional custom expiration date. Defaults to 30 days from now",
-        examples=["2024-03-15", "2024-04-01"],
-    )
-
-    notes: str | None = Field(
-        default=None,
-        description="Optional notes about this reservation",
-        max_length=500,
-        examples=["Need for book club meeting on March 15", "Research deadline April 1"],
-    )
-
-    @field_validator("expiration_date")
-    @classmethod
-    def validate_expiration_date(cls, v: date | None) -> date | None:
-        """Ensure expiration date is in the future and reasonable."""
-        if v is not None:
-            if v <= datetime.now().date():
-                raise ValueError("Expiration date must be in the future")
-            if v > datetime.now().date() + timedelta(days=90):
-                raise ValueError("Expiration date cannot be more than 90 days in the future")
-        return v
-
-
-async def reserve_book_handler(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Process book reservation request.
-
-    Creates reservation in queue, provides position and estimated wait time.
-    Returns reservation details with queue status.
-
-    Client calls: tool.call("reserve_book", {"patron_id": "...", "book_isbn": "..."})
-    """
-    try:
-        # Validate input
+    with get_session() as session:
+        repo = CirculationRepository(session)
         try:
-            params = ReserveBookInput.model_validate(arguments)
-        except Exception as e:
-            logger.warning("Invalid reservation parameters: %s", e)
-            return _format_error_response("Invalid parameters", str(e))
+            checkout = repo.checkout_book(
+                CheckoutCreateSchema(
+                    patron_id=patron_id, book_isbn=book_isbn, due_date=due_date, notes=notes
+                )
+            )
+        except NotFoundError as e:
+            _log_operation("checkout_book_failed", patron_id=patron_id, error="not_found")
+            raise ToolError(str(e)) from e
+        except RepositoryException as e:
+            _log_operation("checkout_book_failed", patron_id=patron_id, error="business_rule")
+            raise ToolError(str(e)) from e
 
-        # Log operation start
-        _log_operation(
-            "reserve_book_start",
-            patron_id=params.patron_id,
-            book_isbn=params.book_isbn,
-            expiration_date=params.expiration_date,
-            has_notes=bool(params.notes),
+    message = (
+        f"Checked out '{checkout.book_isbn}' to {checkout.patron_id}. "
+        f"Due {checkout.due_date.strftime('%B %d, %Y')} "
+        f"({checkout.loan_period_days}-day loan)."
+    )
+    _log_operation(
+        "checkout_book_success",
+        checkout_id=checkout.id,
+        patron_id=checkout.patron_id,
+        due_date=checkout.due_date.isoformat(),
+    )
+    return CheckoutResult(
+        checkout_id=checkout.id,
+        patron_id=checkout.patron_id,
+        book_isbn=checkout.book_isbn,
+        checkout_date=checkout.checkout_date.isoformat(),
+        due_date=checkout.due_date.isoformat(),
+        status=str(checkout.status),
+        loan_period_days=checkout.loan_period_days,
+        message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Processing returns (fines, condition, availability)
+# ---------------------------------------------------------------------------
+
+
+async def return_book(
+    checkout_id: Annotated[
+        str,
+        Field(
+            description="ID of the checkout record being returned",
+            pattern=r"^checkout_[a-zA-Z0-9]+$",
+        ),
+    ],
+    condition: Annotated[
+        Literal["excellent", "good", "fair", "damaged", "lost"],
+        Field(description="Condition of the returned book"),
+    ] = "good",
+    notes: Annotated[
+        str | None, Field(description="Notes about the return, e.g. damage details", max_length=500)
+    ] = None,
+    rating: Annotated[
+        int | None, Field(description="Optional patron rating (1-5 stars)", ge=1, le=5)
+    ] = None,
+    review: Annotated[
+        str | None, Field(description="Optional patron review text", max_length=1000)
+    ] = None,
+) -> ReturnResult:
+    """Process a book return.
+
+    Restores availability, calculates late fines at $0.25/day, and records
+    the book's condition. Ratings and reviews are logged for future use.
+    """
+    _log_operation("return_book_start", checkout_id=checkout_id, condition=condition)
+
+    with get_session() as session:
+        repo = CirculationRepository(session)
+        try:
+            return_record, _ = repo.return_book(
+                ReturnProcessSchema(
+                    checkout_id=checkout_id,
+                    condition=condition,
+                    notes=notes,
+                    processed_by="mcp_tool",
+                )
+            )
+        except NotFoundError as e:
+            raise ToolError(str(e)) from e
+        except RepositoryException as e:
+            raise ToolError(str(e)) from e
+
+    if rating or review:
+        logger.info("Review received | rating=%s review=%s", rating, (review or "")[:100])
+
+    message = f"Returned '{return_record.book_isbn}'."
+    if return_record.late_days > 0:
+        message += (
+            f" {return_record.late_days} day(s) late — fine assessed: "
+            f"${return_record.fine_assessed:.2f}."
         )
+    else:
+        message += " Returned on time, no fines."
+    if condition != "good":
+        message += f" Condition noted: {condition}."
 
-        # Execute reservation
-        with get_session() as session:
-            try:
-                repo = CirculationRepository(session)
+    _log_operation(
+        "return_book_success",
+        return_id=return_record.id,
+        late_days=return_record.late_days,
+        fine_assessed=return_record.fine_assessed,
+    )
+    return ReturnResult(
+        return_id=return_record.id,
+        checkout_id=return_record.checkout_id,
+        book_isbn=return_record.book_isbn,
+        return_date=return_record.return_date.isoformat(),
+        condition=return_record.condition,
+        late_days=return_record.late_days,
+        fine_assessed=return_record.fine_assessed,
+        fine_outstanding=return_record.fine_outstanding,
+        message=message,
+    )
 
-                # Convert to repository schema
-                reservation_data = ReservationCreateSchema(
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    expiration_date=params.expiration_date,
-                    notes=params.notes,
+
+# ---------------------------------------------------------------------------
+# reserve_book
+# ---------------------------------------------------------------------------
+
+
+async def reserve_book(
+    patron_id: Annotated[str, PATRON_ID_FIELD],
+    book_isbn: Annotated[str, ISBN_FIELD],
+    expiration_date: Annotated[
+        date | None,
+        Field(description="When the hold expires (defaults to 30 days out, max 90)"),
+    ] = None,
+    notes: Annotated[
+        str | None, Field(description="Optional notes for the reservation", max_length=500)
+    ] = None,
+) -> ReservationResult:
+    """Reserve a book that is currently unavailable.
+
+    Places the patron in the hold queue and reports their position and
+    estimated wait. The reservation expires if not fulfilled in time.
+    """
+    today = datetime.now().date()
+    if expiration_date is not None:
+        if expiration_date <= today:
+            raise ToolError("Expiration date must be in the future.")
+        if expiration_date > today + timedelta(days=90):
+            raise ToolError("Expiration date cannot be more than 90 days out.")
+
+    _log_operation("reserve_book_start", patron_id=patron_id, book_isbn=book_isbn)
+
+    with get_session() as session:
+        repo = CirculationRepository(session)
+        try:
+            reservation = repo.create_reservation(
+                ReservationCreateSchema(
+                    patron_id=patron_id,
+                    book_isbn=book_isbn,
+                    expiration_date=expiration_date,
+                    notes=notes,
                 )
+            )
+            queue_info = repo.get_reservation_queue_info(book_isbn)
+        except NotFoundError as e:
+            raise ToolError(str(e)) from e
+        except RepositoryException as e:
+            raise ToolError(str(e)) from e
 
-                # Create reservation
-                reservation = repo.create_reservation(reservation_data)
+    message = (
+        f"Reserved '{reservation.book_isbn}' for {reservation.patron_id}. "
+        f"Queue position: {reservation.queue_position}"
+    )
+    if queue_info.estimated_wait_days:
+        message += f" (estimated wait: {queue_info.estimated_wait_days} days)"
+    message += f". Expires {reservation.expiration_date.strftime('%B %d, %Y')}."
 
-                # Get queue information for context
-                queue_info = repo.get_reservation_queue_info(params.book_isbn)
-
-            except NotFoundError as e:
-                logger.info("Reservation failed - entity not found: %s", e)
-                _log_operation(
-                    "reserve_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="not_found",
-                    error_details=str(e),
-                )
-                return _format_error_response("Not found", str(e))
-
-            except RepositoryException as e:
-                logger.info("Reservation failed - business rule: %s", e)
-                _log_operation(
-                    "reserve_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="business_rule",
-                    error_details=str(e),
-                )
-                return _format_error_response("Operation failed", str(e))
-
-            except Exception as e:
-                logger.exception("Reservation database error")
-                _log_operation(
-                    "reserve_book_failed",
-                    patron_id=params.patron_id,
-                    book_isbn=params.book_isbn,
-                    error_type="database_error",
-                    error_details=str(e),
-                )
-                return _format_error_response("Database error", f"Reservation failed: {e!s}")
-
-        # Format response with queue position
-        message = (
-            f"Successfully reserved book '{reservation.book_isbn}' "
-            f"for patron '{reservation.patron_id}'. "
-            f"Queue position: {reservation.queue_position}"
-        )
-
-        if queue_info.estimated_wait_days:
-            message += f" (estimated wait: {queue_info.estimated_wait_days} days)"
-
-        message += f". Reservation expires on {reservation.expiration_date.strftime('%B %d, %Y')}"
-
-        # Log successful operation
-        _log_operation(
-            "reserve_book_success",
-            reservation_id=reservation.id,
-            patron_id=reservation.patron_id,
-            book_isbn=reservation.book_isbn,
-            queue_position=reservation.queue_position,
-            estimated_wait_days=queue_info.estimated_wait_days,
-            expiration_date=reservation.expiration_date.isoformat(),
-        )
-
-        return {
-            "content": [{"type": "text", "text": message}],
-            "data": {
-                "reservation": {
-                    "id": reservation.id,
-                    "patron_id": reservation.patron_id,
-                    "book_isbn": reservation.book_isbn,
-                    "reservation_date": reservation.reservation_date.isoformat(),
-                    "expiration_date": reservation.expiration_date.isoformat(),
-                    "status": reservation.status,
-                    "queue_position": reservation.queue_position,
-                    "estimated_wait_days": queue_info.estimated_wait_days,
-                    "total_in_queue": queue_info.total_reservations,
-                }
-            },
-        }
-
-    except Exception as e:
-        logger.exception("Unexpected error in reserve_book tool")
-        return _format_error_response("Unexpected error", str(e))
-
-
-checkout_book = {
-    "name": "checkout_book",
-    "description": (
-        "Check out a book to a patron. Creates a loan record, updates book availability, "
-        "and sets the due date. Validates patron eligibility (active membership, within "
-        "borrowing limits, no excessive fines) and book availability before processing."
-    ),
-    "inputSchema": CheckoutBookInput.model_json_schema(),
-    "handler": checkout_book_handler,
-}
-
-return_book = {
-    "name": "return_book",
-    "description": (
-        "Process a book return. Updates the checkout record, restores book availability, "
-        "calculates any late fines, and records the book's condition. Optionally accepts "
-        "patron ratings and reviews for the book."
-    ),
-    "inputSchema": ReturnBookInput.model_json_schema(),
-    "handler": return_book_handler,
-}
-
-reserve_book = {
-    "name": "reserve_book",
-    "description": (
-        "Reserve an unavailable book. Places the patron in a queue and provides queue "
-        "position and estimated wait time. The reservation expires after a specified "
-        "period if not fulfilled. Patrons are notified when their reserved book becomes available."
-    ),
-    "inputSchema": ReserveBookInput.model_json_schema(),
-    "handler": reserve_book_handler,
-}
+    _log_operation(
+        "reserve_book_success",
+        reservation_id=reservation.id,
+        queue_position=reservation.queue_position,
+    )
+    return ReservationResult(
+        reservation_id=reservation.id,
+        patron_id=reservation.patron_id,
+        book_isbn=reservation.book_isbn,
+        reservation_date=reservation.reservation_date.isoformat(),
+        expiration_date=reservation.expiration_date.isoformat(),
+        status=str(reservation.status),
+        queue_position=reservation.queue_position,
+        estimated_wait_days=queue_info.estimated_wait_days,
+        total_in_queue=queue_info.total_reservations,
+        message=message,
+    )

--- a/virtual-library-mcp/tools/membership.py
+++ b/virtual-library-mcp/tools/membership.py
@@ -1,0 +1,118 @@
+"""Membership Tool - Interactive Renewal via Elicitation
+
+The clearest demonstration of MCP elicitation (2025-11-25): the tool is
+called with just a patron ID, then asks the USER — through the client —
+which renewal term to apply. Shows:
+
+- Enum elicitation: response_type=Literal[...] renders as a select list
+  (SEP-1330 standardized enum schemas in the 2025-11-25 revision)
+- The accept / decline / cancel action triple
+- A declined elicitation as a normal outcome, not an error
+"""
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Annotated, Literal, cast
+
+from fastmcp import Context
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
+
+from database.patron_repository import PatronRepository, PatronUpdateSchema
+from database.session import get_session
+from models.patron import PatronStatus
+
+logger = logging.getLogger(__name__)
+
+RenewalTerm = Literal["6 months", "12 months", "24 months"]
+TERM_DAYS = {"6 months": 182, "12 months": 365, "24 months": 730}
+
+
+class RenewalResult(BaseModel):
+    """Structured outcome of a renewal attempt."""
+
+    patron_id: str
+    patron_name: str
+    renewed: bool
+    term: str | None = None
+    previous_expiration: str | None = None
+    new_expiration: str | None = None
+    status: str
+    message: str
+
+
+async def renew_membership(
+    patron_id: Annotated[
+        str,
+        Field(
+            description="Patron identifier, e.g. 'patron_00042'",
+            pattern=r"^patron_[a-zA-Z0-9_]{5,}$",
+        ),
+    ],
+    ctx: Context,
+) -> RenewalResult:
+    """Renew a patron's library membership interactively.
+
+    The renewal term is not a tool argument by design: the server elicits
+    it from the user mid-execution, demonstrating how MCP tools can gather
+    input progressively instead of requiring everything upfront.
+    """
+    with get_session() as session:
+        patron = PatronRepository(session).get_by_id(patron_id)
+    if patron is None:
+        raise ToolError(f"Patron {patron_id} not found.")
+
+    current_expiration = patron.expiration_date
+
+    try:
+        answer = await ctx.elicit(
+            f"Renew membership for {patron.name} "
+            f"(current expiration: {current_expiration or 'none on file'}). "
+            "Which term should be applied?",
+            response_type=RenewalTerm,
+        )
+    except Exception as e:
+        # No elicitation capability on this client: the term genuinely
+        # cannot be collected, so surface a actionable tool error.
+        raise ToolError(
+            "This client does not support elicitation; call the tool from a "
+            "client that does, or update the patron's expiration directly."
+        ) from e
+
+    if answer.action != "accept":
+        logger.info("Renewal %s by user for %s", answer.action, patron_id)
+        return RenewalResult(
+            patron_id=patron_id,
+            patron_name=patron.name,
+            renewed=False,
+            status=str(patron.status),
+            message=f"Renewal {answer.action}ed by the user — no changes made.",
+        )
+
+    term = cast("RenewalTerm", answer.data)
+    today = datetime.now().date()
+    base: date = max(current_expiration, today) if current_expiration else today
+    new_expiration = base + timedelta(days=TERM_DAYS[term])
+
+    update_fields: dict = {"expiration_date": new_expiration}
+    if patron.status == PatronStatus.EXPIRED:
+        # A lapsed membership becomes active again upon renewal.
+        update_fields["status"] = PatronStatus.ACTIVE
+    with get_session() as session:
+        repo = PatronRepository(session)
+        updated = repo.update(patron_id, PatronUpdateSchema(**update_fields))
+
+    message = (
+        f"Renewed {updated.name}'s membership for {term}: now expires {new_expiration.isoformat()}."
+    )
+    logger.info("renew_membership_success | patron=%s term=%s", patron_id, term)
+    return RenewalResult(
+        patron_id=patron_id,
+        patron_name=updated.name,
+        renewed=True,
+        term=term,
+        previous_expiration=current_expiration.isoformat() if current_expiration else None,
+        new_expiration=new_expiration.isoformat(),
+        status=str(updated.status),
+        message=message,
+    )

--- a/virtual-library-mcp/tools/search.py
+++ b/virtual-library-mcp/tools/search.py
@@ -1,236 +1,162 @@
 """Search Tool - Library Catalog Search
 
 Provides full-text and filtered search across the book catalog.
-Clients use this tool to find books with pagination and sorting.
 
-Usage: tool.call("search_catalog", {"query": "python", "page_size": 20})
+MCP concepts demonstrated:
+- Typed parameters: FastMCP turns the function signature into a rich JSON
+  Schema (field names, types, constraints, descriptions) — exactly what an
+  LLM needs to call the tool correctly without guessing.
+- Structured output: the typed ``SearchResults`` return model becomes the
+  tool's outputSchema, and results arrive as machine-readable
+  structuredContent alongside the human-readable summary.
+- Tool execution errors (SEP-1303): invalid usage raises ToolError, which
+  reaches the model as an isError result it can self-correct from.
 """
 
 import logging
-from typing import Any
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from fastmcp.exceptions import ToolError
+from pydantic import BaseModel, Field
 
 from database.book_repository import BookRepository, BookSearchParams, BookSortOptions
 from database.repository import PaginationParams
 from database.session import get_session
 from models.book import Book
 
-# Observability is handled by middleware, not decorators
-
 logger = logging.getLogger(__name__)
 
+SORT_OPTIONS: dict[str, BookSortOptions] = {
+    "relevance": BookSortOptions.TITLE,  # until relevance scoring exists
+    "title": BookSortOptions.TITLE,
+    "author": BookSortOptions.AUTHOR,
+    "publication_year": BookSortOptions.PUBLICATION_YEAR,
+    "availability": BookSortOptions.AVAILABILITY,
+}
 
-class SearchCatalogInput(BaseModel):
-    """Input schema for the search_catalog tool."""
 
-    query: str | None = Field(
-        default=None,
-        description="General search term to match against title, author, description, or ISBN",
-        min_length=1,
-        max_length=200,
-        examples=["gatsby", "python programming", "978-0134685479"],
+class BookSummary(BaseModel):
+    """A catalog entry as returned in search results."""
+
+    isbn: str
+    title: str
+    author_id: str
+    genre: str
+    publication_year: int
+    available_copies: int
+    total_copies: int
+    is_available: bool
+    description: str | None = None
+
+
+class PageInfo(BaseModel):
+    """Pagination metadata for a result page."""
+
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+
+
+class SearchResults(BaseModel):
+    """Structured output for search_catalog (becomes the tool's outputSchema)."""
+
+    summary: str
+    books: list[BookSummary]
+    pagination: PageInfo
+
+
+def _to_summary(book: Book) -> BookSummary:
+    return BookSummary(
+        isbn=book.isbn,
+        title=book.title,
+        author_id=book.author_id,
+        genre=book.genre,
+        publication_year=book.publication_year,
+        available_copies=book.available_copies,
+        total_copies=book.total_copies,
+        is_available=book.is_available,
+        description=book.description,
     )
 
-    genre: str | None = Field(
-        default=None,
-        description="Filter by book genre (exact match, case-insensitive)",
-        examples=["Fiction", "Non-Fiction", "Science Fiction", "Biography"],
-    )
 
-    author: str | None = Field(
-        default=None,
-        description="Filter by author name (partial match, case-insensitive)",
-        min_length=1,
-        max_length=100,
-        examples=["Fitzgerald", "King", "Rowling"],
-    )
+async def search_catalog(
+    query: Annotated[
+        str | None,
+        Field(description="Full-text search across title, description, and ISBN", max_length=200),
+    ] = None,
+    genre: Annotated[
+        str | None,
+        Field(description="Filter by genre, e.g. 'Science Fiction' (case-insensitive)"),
+    ] = None,
+    author: Annotated[
+        str | None,
+        Field(
+            description="Filter by author name (partial match, case-insensitive)", max_length=100
+        ),
+    ] = None,
+    available_only: Annotated[
+        bool, Field(description="Only return books with copies on the shelf")
+    ] = False,
+    page: Annotated[int, Field(description="Page number (1-indexed)", ge=1, le=1000)] = 1,
+    page_size: Annotated[int, Field(description="Results per page", ge=1, le=50)] = 10,
+    sort_by: Annotated[
+        Literal["relevance", "title", "author", "publication_year", "availability"],
+        Field(description="Sort order for results"),
+    ] = "relevance",
+    sort_desc: Annotated[bool, Field(description="Sort in descending order")] = False,
+) -> SearchResults:
+    """Search the library catalog for books.
 
-    available_only: bool = Field(
-        default=False,
-        description="Only return books with available copies",
-    )
+    Supports full-text search, filtering by genre and author, pagination,
+    and sorting. At least one of query, genre, or author must be provided.
+    """
+    query = query.strip() if query and query.strip() else None
+    author = author.strip() if author and author.strip() else None
+    genre = genre.strip().title() if genre and genre.strip() else None
 
-    page: int = Field(
-        default=1,
-        description="Page number (1-indexed)",
-        ge=1,
-        le=1000,
-    )
+    if not any([query, genre, author]):
+        # ToolError (not a protocol error) so the model can retry with criteria.
+        raise ToolError("Provide at least one search criterion: query, genre, or author.")
 
-    page_size: int = Field(
-        default=10,
-        description="Number of results per page",
-        ge=1,
-        le=50,  # Limit to prevent resource exhaustion
-    )
-
-    # Sorting parameters
-    sort_by: str = Field(
-        default="relevance",
-        description="Field to sort results by",
-        pattern="^(relevance|title|author|publication_year|availability)$",
-    )
-
-    sort_desc: bool = Field(
-        default=False,
-        description="Sort in descending order",
-    )
-
-    @field_validator("query", "author")
-    @classmethod
-    def strip_whitespace(cls, v: str | None) -> str | None:
-        """Strip leading/trailing whitespace from string inputs."""
-        if v is not None:
-            v = v.strip()
-            if not v:  # Empty after stripping
-                return None
-        return v
-
-    @field_validator("genre")
-    @classmethod
-    def normalize_genre(cls, v: str | None) -> str | None:
-        """Normalize genre to title case for consistent matching."""
-        if v is not None:
-            v = v.strip().title()
-            if not v:
-                return None
-        return v
-
-    def to_search_params(self) -> BookSearchParams:
-        """Convert tool input to repository search parameters."""
-        return BookSearchParams(
-            query=self.query,
-            genre=self.genre,
-            author_name=self.author,
-            available_only=self.available_only,
+    with get_session() as session:
+        repo = BookRepository(session)
+        result = repo.search(
+            search_params=BookSearchParams(
+                query=query, genre=genre, author_name=author, available_only=available_only
+            ),
+            pagination=PaginationParams(page=page, page_size=page_size),
+            sort_by=SORT_OPTIONS[sort_by],
+            sort_desc=sort_desc,
         )
 
-    def to_pagination_params(self) -> PaginationParams:
-        """Convert tool input to pagination parameters."""
-        return PaginationParams(page=self.page, page_size=self.page_size)
+    books = [_to_summary(book) for book in result.items]
+    if not books:
+        summary = "No books found matching your search criteria."
+    else:
+        summary = f"Found {result.total} book(s) matching your search"
+        if result.total > len(books):
+            summary += f" (showing page {result.page} of {result.total_pages})"
 
+    logger.info(
+        "search_catalog | query=%s genre=%s author=%s -> %d results",
+        query,
+        genre,
+        author,
+        result.total,
+    )
 
-def format_book_for_tool_response(book: Book) -> dict[str, Any]:
-    """Format a book model for tool response."""
-    return {
-        "isbn": book.isbn,
-        "title": book.title,
-        "author_id": book.author_id,
-        "genre": book.genre,
-        "publication_year": book.publication_year,
-        "available_copies": book.available_copies,
-        "total_copies": book.total_copies,
-        "description": book.description,
-        "cover_url": book.cover_url,
-        "is_available": book.is_available,
-    }
-
-
-async def search_catalog_handler(arguments: dict[str, Any]) -> dict[str, Any]:
-    """Process catalog search request.
-
-    Validates input, searches books by query/genre/author,
-    returns paginated results with availability status.
-
-    Client calls: tool.call("search_catalog", {"query": "...", "page": 1})
-    """
-    try:
-        # Validate input
-        try:
-            params = SearchCatalogInput.model_validate(arguments)
-        except Exception as e:
-            logger.warning("Invalid search parameters: %s", e)
-            return {
-                "isError": True,
-                "content": [{"type": "text", "text": f"Invalid search parameters: {e}"}],
-            }
-
-        # Require at least one search criterion
-        if not any([params.query, params.genre, params.author]):
-            return {
-                "isError": True,
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "Please provide at least one search criterion (query, genre, or author)",
-                    }
-                ],
-            }
-
-        # Execute search
-        with get_session() as session:
-            try:
-                repo = BookRepository(session)
-
-                # Map sort parameter to enum
-                sort_by = BookSortOptions.TITLE
-                if params.sort_by == "title":
-                    sort_by = BookSortOptions.TITLE
-                elif params.sort_by == "author":
-                    sort_by = BookSortOptions.AUTHOR
-                elif params.sort_by == "publication_year":
-                    sort_by = BookSortOptions.PUBLICATION_YEAR
-                elif params.sort_by == "availability":
-                    sort_by = BookSortOptions.AVAILABILITY
-                # "relevance" uses default (title) until we implement scoring
-
-                # Execute search
-                result = repo.search(
-                    search_params=params.to_search_params(),
-                    pagination=params.to_pagination_params(),
-                    sort_by=sort_by,
-                    sort_desc=params.sort_desc,
-                )
-
-            except Exception as e:
-                logger.exception("Search execution failed")
-                return {
-                    "isError": True,
-                    "content": [{"type": "text", "text": f"Search failed: {e!s}"}],
-                }
-
-        # Format response
-        books_data = [format_book_for_tool_response(book) for book in result.items]
-
-        # Build response message
-        if not books_data:
-            message = "No books found matching your search criteria."
-        else:
-            message = f"Found {result.total} book(s) matching your search"
-            if result.total > len(books_data):
-                message += f" (showing page {result.page} of {result.total_pages})"
-
-        return {
-            "content": [{"type": "text", "text": message}],
-            "data": {
-                "books": books_data,
-                "pagination": {
-                    "page": result.page,
-                    "page_size": result.page_size,
-                    "total": result.total,
-                    "total_pages": result.total_pages,
-                    "has_next": result.has_next,
-                    "has_previous": result.has_previous,
-                },
-            },
-        }
-
-    except Exception as e:
-        logger.exception("Unexpected error in search_catalog tool")
-        return {
-            "isError": True,
-            "content": [{"type": "text", "text": f"An unexpected error occurred: {e!s}"}],
-        }
-
-
-search_catalog = {
-    "name": "search_catalog",
-    "description": (
-        "Search the library catalog for books. Supports full-text search, "
-        "filtering by genre and author, pagination, and sorting. "
-        "At least one search criterion must be provided."
-    ),
-    "inputSchema": SearchCatalogInput.model_json_schema(),
-    "handler": search_catalog_handler,
-}
+    return SearchResults(
+        summary=summary,
+        books=books,
+        pagination=PageInfo(
+            page=result.page,
+            page_size=result.page_size,
+            total=result.total,
+            total_pages=result.total_pages,
+            has_next=result.has_next,
+            has_previous=result.has_previous,
+        ),
+    )

--- a/virtual-library-mcp/uv.lock
+++ b/virtual-library-mcp/uv.lock
@@ -15,6 +15,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -65,6 +74,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "burner-redis"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
 ]
 
 [[package]]
@@ -249,6 +274,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -339,6 +373,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
     { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
     { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -485,6 +527,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
 ]
 
+[package.optional-dependencies]
+tasks = [
+    { name = "fastmcp-slim", extra = ["tasks"] },
+]
+
 [[package]]
 name = "fastmcp-slim"
 version = "3.4.2"
@@ -534,6 +581,9 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+tasks = [
+    { name = "pydocket" },
 ]
 
 [[package]]
@@ -1037,6 +1087,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1074,6 +1133,9 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]
@@ -1195,6 +1257,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/5f/2f68c38ac3fdbff3cdec3ccfe31303ae5972f3e3f1c365d0ec71573dfd2e/pydocket-0.21.1.tar.gz", hash = "sha256:79d19d5f3be29caa23eba95226a516f8b2aed3ba1ad7830095fdce59f49b51f7", size = 399652, upload-time = "2026-05-29T21:04:10.855Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/6bd186338cf4abb318825d9e8d2d2cf069432f9217d17f78f61204eaba70/pydocket-0.21.1-py3-none-any.whl", hash = "sha256:7f3b12c307488efbfde96f76dac533babf5dff4ce72dc0a108a49de03ab39564", size = 117222, upload-time = "2026-05-29T21:04:09.375Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1292,6 +1378,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
@@ -1372,6 +1467,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]
@@ -1578,6 +1682,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.50"
 source = { registry = "https://pypi.org/simple" }
@@ -1642,6 +1755,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]
@@ -1711,7 +1839,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "faker" },
-    { name = "fastmcp" },
+    { name = "fastmcp", extra = ["tasks"] },
     { name = "httpx" },
     { name = "logfire" },
     { name = "pydantic" },
@@ -1733,7 +1861,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faker", specifier = ">=40" },
-    { name = "fastmcp", specifier = ">=3.4,<4" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.4,<4" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "logfire", specifier = ">=4" },
     { name = "pydantic", specifier = ">=2.13" },


### PR DESCRIPTION
## Summary

**Stacked on #55.** Brings the server to full MCP **2025-11-25** feature coverage on FastMCP 3.

### The headline fix
Every tool previously exposed `{"arguments": object}` as its input schema — LLMs saw no field names or types at all. Tools are now plain typed functions and FastMCP generates real schemas (names, types, constraints, enums, descriptions) from the signatures.

### New protocol features
| Feature | Spec ref | Where |
|---|---|---|
| Elicitation (approval) | 2025-11-25 | `checkout_book` confirms when patron has fines |
| Elicitation (enum select) | SEP-1330 | new `renew_membership` elicits the term |
| Tool-enabled sampling | SEP-1577 | `similar_books` insight hands the client LLM a catalog-search tool |
| Background tasks | SEP-1686 | `regenerate_catalog` (`task=optional`, `fastmcp[tasks]`) |
| Icons | SEP-973 | data-URI SVGs on all tools/resources/prompts |
| Tool annotations | — | read-only/destructive/idempotent hints on every tool |
| Structured output | — | Pydantic return models → outputSchema + structuredContent |
| `list_changed` notifications | — | maintenance mode hides/restores the recommendations template |
| Tool execution errors | SEP-1303 | `ToolError` for business failures (model-recoverable) |

### Bugs found by doing this
- `return_book` refused **OVERDUE** checkouts — the one state where returns assess fines
- Catalog maintenance called repository methods that don't exist (`get_active_loans`, `get_overdue_loans`, `PatronRepository.list`) — pyright had been warning about these
- Bulk import: one duplicate ISBN poisoned the whole batch (now per-row SAVEPOINTs)
- **Security**: bulk import accepted arbitrary filesystem paths; now confined to `data/` (path-traversal guard with `resolve()` + `is_relative_to`)

### Tests
Rewritten against the FastMCP in-memory client, so they exercise the real protocol path: schema validation, elicitation round-trips (accept/decline/never-asked), sampling handlers + fallback, progress notifications, and `list_changed` capture. `just test` ✅ 198 · `just lint` ✅ · `just typecheck` ✅ 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)