### PR TITLE
OAuth 2.1 + PKCE and Streamable HTTP transport

### DIFF
--- a/virtual-library-mcp/.env.sample
+++ b/virtual-library-mcp/.env.sample
@@ -14,15 +14,35 @@ VIRTUAL_LIBRARY_SERVER_VERSION=0.1.0
 VIRTUAL_LIBRARY_DATABASE_PATH=./virtual_library.db
 
 # === Transport Configuration ===
-# Primary transport: stdio or streamable_http
-# stdio: For local CLI usage (recommended for development)
-# streamable_http: For HTTP-based clients with optional streaming (future feature)
+# Primary transport: stdio (local development) or http (Streamable HTTP)
 VIRTUAL_LIBRARY_TRANSPORT=stdio
 
-# HTTP transport settings (for future Streamable HTTP support)
-# Only used when TRANSPORT=streamable_http
+# HTTP transport settings (used when TRANSPORT=http)
+# Bind to 127.0.0.1 locally; containers set 0.0.0.0 explicitly.
 VIRTUAL_LIBRARY_HTTP_HOST=127.0.0.1
 VIRTUAL_LIBRARY_HTTP_PORT=8080
+VIRTUAL_LIBRARY_HTTP_PATH=/mcp
+
+# === Authentication (OAuth 2.1 with PKCE) ===
+# Required for any non-local HTTP deployment. The server refuses to start
+# an unauthenticated HTTP listener unless ALLOW_INSECURE_HTTP=true.
+VIRTUAL_LIBRARY_AUTH_ENABLED=false
+
+# Public URL of this server - must be https:// (http:// only for localhost)
+# VIRTUAL_LIBRARY_BASE_URL=https://your-service.a.run.app
+
+# Google OAuth client (Google Cloud Console -> APIs & Services -> Credentials)
+# Authorized redirect URI must be: {BASE_URL}/auth/callback
+# VIRTUAL_LIBRARY_GOOGLE_CLIENT_ID=1234567890.apps.googleusercontent.com
+# VIRTUAL_LIBRARY_GOOGLE_CLIENT_SECRET=GOCSPX-...   # keep out of source control!
+
+# Authorization allowlist (JSON array): which Google accounts may use the
+# server. Empty/unset = any authenticated Google account. Recommended for
+# personal deployments:
+# VIRTUAL_LIBRARY_AUTH_ALLOWED_EMAILS=["you@gmail.com"]
+
+# Local development escape hatch: serve HTTP without auth on localhost ONLY.
+# VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP=true
 
 # === Security Configuration ===
 # External API credentials (if integrating with book APIs)

--- a/virtual-library-mcp/auth.py
+++ b/virtual-library-mcp/auth.py
@@ -1,0 +1,86 @@
+"""OAuth 2.1 authentication for the Virtual Library MCP Server.
+
+MCP authorization (2025-11-25 spec) in one paragraph: the MCP server is an
+OAuth 2.0 **Protected Resource**. It advertises RFC 9728 Protected Resource
+Metadata at /.well-known/oauth-protected-resource pointing clients at an
+authorization server. Clients register (dynamically, or via Client ID
+Metadata Documents per SEP-991), run an Authorization Code + PKCE flow
+(S256 — mandatory in OAuth 2.1), and present bearer tokens on every HTTP
+request. The server validates each token and its scopes before serving.
+
+This server uses FastMCP's GoogleProvider, an **OAuth Proxy**: toward MCP
+clients it speaks the full spec-compliant flow above; upstream it bridges
+to Google's fixed-credential OAuth (Google issues no dynamic clients).
+Users therefore sign in with real Google accounts, and the deployment
+needs exactly one Google OAuth client.
+
+Security posture implemented here:
+- PKCE (S256) enforced by the provider for every client
+- Tokens are validated server-side on every request; scopes checked
+- Authorization consent screen enabled (require_authorization_consent)
+- Client ID Metadata Documents enabled (enable_cimd, SEP-991)
+- HTTPS required for the public base URL (config validator)
+- The HTTP transport refuses to start unauthenticated unless explicitly
+  opted out via VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP (dev only)
+"""
+
+import logging
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth import AuthProvider
+from fastmcp.server.auth.providers.google import GoogleProvider
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class EmailAllowlistMiddleware(Middleware):
+    """Authorization layer on top of authentication.
+
+    Google sign-in proves WHO the caller is (authentication); this
+    middleware decides whether that identity may use the server at all
+    (authorization). Without it, "authenticated" means "anyone with a
+    Google account" — fine for a public demo catalog, wrong for anything
+    holding real data. Applied only when an allowlist is configured.
+    """
+
+    def __init__(self, allowed_emails: list[str]):
+        self.allowed = {email.strip().lower() for email in allowed_emails if email.strip()}
+
+    async def on_request(self, context: MiddlewareContext, call_next):
+        token = get_access_token()
+        email = (token.claims.get("email") or "").lower() if token else ""
+        if email not in self.allowed:
+            logger.warning("Authorization denied for %s", email or "<no email claim>")
+            raise ToolError("This account is not authorized to use this server.")
+        return await call_next(context)
+
+
+def build_auth_provider(config: ServerConfig) -> AuthProvider | None:
+    """Construct the OAuth provider from configuration, or None when disabled.
+
+    Returns None for stdio transport and for explicitly-insecure local HTTP.
+    The decision to refuse unauthenticated HTTP lives in server.main(), not
+    here — this factory only reflects configuration.
+    """
+    if not config.auth_enabled:
+        return None
+
+    # The config model validator guarantees these are present.
+    assert config.base_url is not None
+    assert config.google_client_id is not None
+    assert config.google_client_secret is not None
+
+    logger.info("OAuth 2.1 enabled: Google identity, base_url=%s", config.base_url)
+    return GoogleProvider(
+        client_id=config.google_client_id,
+        client_secret=config.google_client_secret,
+        base_url=config.base_url,
+        required_scopes=config.auth_required_scopes,
+        # Defaults kept explicit for the reader:
+        require_authorization_consent=True,  # user sees a consent page
+        enable_cimd=True,  # SEP-991 client registration via metadata documents
+    )

--- a/virtual-library-mcp/config.py
+++ b/virtual-library-mcp/config.py
@@ -9,7 +9,7 @@ This module demonstrates MCP best practices for configuration:
 
 from pathlib import Path
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -72,16 +72,14 @@ class ServerConfig(BaseSettings):
 
     transport: str = Field(
         default="stdio",
-        description="Primary transport mechanism",
-        # We start with stdio, but design for extensibility to Streamable HTTP
-        pattern=r"^(stdio|streamable_http)$",
+        description="Transport: 'stdio' for local development, 'http' for Streamable HTTP",
+        pattern=r"^(stdio|http|streamable_http)$",
     )
 
-    # Streamable HTTP configuration (for future use)
-    # Demonstrates forward-thinking design
+    # Streamable HTTP configuration
     http_host: str = Field(
-        default="127.0.0.1",
-        description="HTTP server host for Streamable HTTP transport",
+        default="127.0.0.1",  # localhost-only by default; 0.0.0.0 only in containers
+        description="HTTP server bind host for Streamable HTTP transport",
     )
 
     http_port: int = Field(
@@ -89,6 +87,65 @@ class ServerConfig(BaseSettings):
         description="HTTP server port for Streamable HTTP transport",
         ge=1024,  # Avoid privileged ports
         le=65535,
+    )
+
+    http_path: str = Field(
+        default="/mcp",
+        description="URL path where the MCP endpoint is mounted",
+        pattern=r"^/[a-zA-Z0-9/_-]*$",
+    )
+
+    # === Authentication (OAuth 2.1, MCP 2025-11-25 authorization spec) ===
+    # The server acts as an OAuth Protected Resource. FastMCP's GoogleProvider
+    # implements the OAuth Proxy pattern: spec-compliant PRM metadata, dynamic
+    # client registration, and PKCE toward MCP clients, bridged to Google's
+    # fixed-credential OAuth upstream.
+
+    auth_enabled: bool = Field(
+        default=False,
+        description="Require OAuth 2.1 bearer tokens on the HTTP transport",
+    )
+
+    base_url: str | None = Field(
+        default=None,
+        description=(
+            "Public URL of this server (e.g. https://library.example.run.app). "
+            "Required when auth is enabled; used for OAuth metadata and callbacks."
+        ),
+    )
+
+    google_client_id: str | None = Field(
+        default=None,
+        description="Google OAuth client ID (from Google Cloud Console)",
+    )
+
+    google_client_secret: str | None = Field(
+        default=None,
+        description="Google OAuth client secret",
+        repr=False,  # never appears in logs or repr
+    )
+
+    auth_required_scopes: list[str] = Field(
+        default=["openid", "https://www.googleapis.com/auth/userinfo.email"],
+        description="OAuth scopes every client token must carry",
+    )
+
+    auth_allowed_emails: list[str] = Field(
+        default=[],
+        description=(
+            "Authorization allowlist: Google account emails permitted to use "
+            "this server. Empty list = any authenticated Google account "
+            "(authentication only, no authorization). For personal deployments, "
+            "set this to your own address(es)."
+        ),
+    )
+
+    allow_insecure_http: bool = Field(
+        default=False,
+        description=(
+            "Explicitly allow running the HTTP transport WITHOUT authentication. "
+            "Local development only - never enable in production."
+        ),
     )
 
     # === Security Configuration ===
@@ -197,6 +254,47 @@ class ServerConfig(BaseSettings):
         if v in reserved_ports:
             raise ValueError(f"Port {v} is commonly reserved, choose another")
         return v
+
+    @field_validator("transport")
+    @classmethod
+    def normalize_transport(cls, v: str) -> str:
+        """Accept the legacy 'streamable_http' spelling but store 'http'."""
+        return "http" if v == "streamable_http" else v
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str | None) -> str | None:
+        """OAuth metadata URLs must be HTTPS except for local development.
+
+        OAuth 2.1 requires TLS for every endpoint involved in the flow;
+        the localhost exception exists only for development loops.
+        """
+        if v is None:
+            return v
+        v = v.rstrip("/")
+        is_local = v.startswith(("http://localhost", "http://127.0.0.1"))
+        if not v.startswith("https://") and not is_local:
+            raise ValueError("base_url must use https:// (http:// allowed only for localhost)")
+        return v
+
+    @model_validator(mode="after")
+    def validate_auth_configuration(self) -> "ServerConfig":
+        """Auth requires complete OAuth configuration before startup."""
+        if self.auth_enabled:
+            missing = [
+                name
+                for name, value in (
+                    ("VIRTUAL_LIBRARY_BASE_URL", self.base_url),
+                    ("VIRTUAL_LIBRARY_GOOGLE_CLIENT_ID", self.google_client_id),
+                    ("VIRTUAL_LIBRARY_GOOGLE_CLIENT_SECRET", self.google_client_secret),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValueError(
+                    f"auth_enabled=true but missing required settings: {', '.join(missing)}"
+                )
+        return self
 
     # === Computed Properties ===
 

--- a/virtual-library-mcp/justfile
+++ b/virtual-library-mcp/justfile
@@ -53,6 +53,17 @@ dev-debug:
     @echo "🐛 Starting server with debug logging..."
     MCP_LOG_LEVEL=DEBUG .venv/bin/python server.py
 
+# Run the Streamable HTTP transport locally WITHOUT auth (localhost only)
+dev-http:
+    @echo "🌐 Starting Streamable HTTP on http://127.0.0.1:8080/mcp (no auth - local dev only)"
+    VIRTUAL_LIBRARY_TRANSPORT=http VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP=true .venv/bin/python server.py
+
+# Run the Streamable HTTP transport with OAuth 2.1 (requires Google creds in .env)
+dev-http-auth:
+    @echo "🔐 Starting Streamable HTTP with OAuth 2.1 on http://127.0.0.1:8080/mcp"
+    @echo "   Requires VIRTUAL_LIBRARY_BASE_URL, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET in .env"
+    VIRTUAL_LIBRARY_TRANSPORT=http VIRTUAL_LIBRARY_AUTH_ENABLED=true .venv/bin/python server.py
+
 # === CODE QUALITY ===
 
 # Run all linting checks

--- a/virtual-library-mcp/server.py
+++ b/virtual-library-mcp/server.py
@@ -7,10 +7,14 @@ A complete MCP server targeting protocol revision 2025-11-25, demonstrating:
   annotations, elicitation, tool-enabled sampling, background tasks
 - Prompts: user-invoked templates for recommendations and reading plans
 - Notifications: resources/list_changed fired on visibility changes
+- Transports: stdio for local development, Streamable HTTP for remote use
+- Authorization: OAuth 2.1 with PKCE on the HTTP transport (see auth.py)
 - Observability: Logfire middleware tracing every protocol message
 
-Transport is selected via config: stdio for local development (default).
-Streamable HTTP with OAuth 2.1 arrives with the deployment work.
+Session-state note: sampling, elicitation, and notifications are
+server->client requests that ride the session's SSE stream, so the HTTP
+transport runs STATEFUL. Scale out with session affinity, not stateless
+round-robin (see the deployment docs).
 """
 
 import logging
@@ -18,10 +22,13 @@ import sys
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 import prompts
 import resources
 import tools
+from auth import EmailAllowlistMiddleware, build_auth_provider
 from config import get_config
 from observability import LOGFIRE_AVAILABLE, initialize_observability
 from observability import get_config as get_obs_config
@@ -43,6 +50,7 @@ initialize_observability()
 mcp = FastMCP(
     name=config.server_name,
     version=config.server_version,
+    auth=build_auth_provider(config),
     instructions=(
         "Virtual Library MCP Server - A comprehensive library management system "
         "demonstrating the full MCP feature surface. Browse the catalog through "
@@ -58,10 +66,62 @@ if obs_config.enabled and LOGFIRE_AVAILABLE:
     logger.info("Enabling observability middleware for MCP protocol tracing")
     mcp.add_middleware(MCPInstrumentationMiddleware())
 
+# Authorization (distinct from authentication): restrict to listed accounts.
+if config.auth_enabled and config.auth_allowed_emails:
+    logger.info("Email allowlist active: %d account(s) authorized", len(config.auth_allowed_emails))
+    mcp.add_middleware(EmailAllowlistMiddleware(config.auth_allowed_emails))
+
 # Each package registers its own components (see <package>/__init__.py).
 resources.register(mcp)
 tools.register(mcp)
 prompts.register(mcp)
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(_: Request) -> JSONResponse:
+    """Liveness probe for Cloud Run / load balancers.
+
+    Custom routes bypass MCP authentication by design — health checks
+    must not require tokens. Nothing sensitive is exposed here.
+    """
+    return JSONResponse({"status": "ok", "service": config.server_name})
+
+
+def _run_http_server() -> None:
+    """Run the Streamable HTTP transport with the configured security posture."""
+    if not config.auth_enabled:
+        if not config.allow_insecure_http:
+            logger.error(
+                "Refusing to serve HTTP without authentication. Either enable "
+                "OAuth (VIRTUAL_LIBRARY_AUTH_ENABLED=true with Google credentials) "
+                "or explicitly opt out for local development "
+                "(VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP=true)."
+            )
+            sys.exit(1)
+        logger.warning(
+            "HTTP transport running WITHOUT authentication (allow_insecure_http=true). "
+            "This must never be exposed beyond localhost."
+        )
+
+    # Basic abuse protection for the remote transport. Token-bucket per
+    # client; generous limits suitable for a demo deployment.
+    from fastmcp.server.middleware.rate_limiting import RateLimitingMiddleware
+
+    mcp.add_middleware(RateLimitingMiddleware(max_requests_per_second=20, burst_capacity=40))
+
+    logger.info(
+        "Streamable HTTP listening on %s:%s%s (auth=%s)",
+        config.http_host,
+        config.http_port,
+        config.http_path,
+        "oauth2.1" if config.auth_enabled else "DISABLED",
+    )
+    mcp.run(
+        transport="http",
+        host=config.http_host,
+        port=config.http_port,
+        path=config.http_path,
+    )
 
 
 def main() -> None:
@@ -82,6 +142,8 @@ def main() -> None:
     try:
         if config.transport == "stdio":
             mcp.run(transport="stdio")
+        elif config.transport == "http":
+            _run_http_server()
         else:
             logger.error("Unsupported transport: %s", config.transport)
             sys.exit(1)

--- a/virtual-library-mcp/tests/test_auth.py
+++ b/virtual-library-mcp/tests/test_auth.py
@@ -1,0 +1,177 @@
+"""Tests for OAuth 2.1 configuration and wiring.
+
+These don't talk to Google — they verify the parts we own: configuration
+validation (fail closed), provider construction, and that the OAuth
+discovery endpoints required by the MCP 2025-11-25 authorization spec
+are actually mounted on the HTTP app.
+"""
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.google import GoogleProvider
+from pydantic import ValidationError
+
+from auth import build_auth_provider
+from config import ServerConfig
+
+FAKE_AUTH = {
+    "auth_enabled": True,
+    "base_url": "https://library.example.app",
+    "google_client_id": "1234567890.apps.googleusercontent.com",
+    "google_client_secret": "GOCSPX-test-secret",
+}
+
+
+def _config(**overrides) -> ServerConfig:
+    return ServerConfig(_env_file=None, **overrides)
+
+
+class TestAuthConfiguration:
+    def test_auth_disabled_needs_nothing(self, clean_env):
+        config = _config()
+        assert config.auth_enabled is False
+        assert build_auth_provider(config) is None
+
+    def test_auth_enabled_requires_credentials(self, clean_env):
+        with pytest.raises(ValidationError, match="missing required settings"):
+            _config(auth_enabled=True)
+
+    def test_auth_enabled_names_each_missing_setting(self, clean_env):
+        with pytest.raises(ValidationError, match="GOOGLE_CLIENT_SECRET"):
+            _config(
+                auth_enabled=True,
+                base_url="https://library.example.app",
+                google_client_id="x.apps.googleusercontent.com",
+            )
+
+    def test_base_url_must_be_https(self, clean_env):
+        with pytest.raises(ValidationError, match="https"):
+            _config(base_url="http://library.example.app")
+
+    def test_localhost_http_base_url_allowed_for_dev(self, clean_env):
+        config = _config(base_url="http://localhost:8080")
+        assert config.base_url == "http://localhost:8080"
+
+    def test_base_url_trailing_slash_stripped(self, clean_env):
+        config = _config(base_url="https://library.example.app/")
+        assert config.base_url == "https://library.example.app"
+
+    def test_secret_never_appears_in_repr(self, clean_env):
+        config = _config(**FAKE_AUTH)
+        assert "GOCSPX-test-secret" not in repr(config)
+
+    def test_legacy_transport_spelling_normalized(self, clean_env):
+        config = _config(transport="streamable_http")
+        assert config.transport == "http"
+
+
+class TestProviderConstruction:
+    def test_full_config_builds_google_provider(self, clean_env):
+        provider = build_auth_provider(_config(**FAKE_AUTH))
+        assert isinstance(provider, GoogleProvider)
+
+    def test_provider_uses_configured_base_url(self, clean_env):
+        provider = build_auth_provider(_config(**FAKE_AUTH))
+        assert str(provider.base_url).rstrip("/") == "https://library.example.app"
+
+
+class TestOAuthDiscoveryEndpoints:
+    """The 2025-11-25 authorization spec requires discoverable metadata."""
+
+    @pytest.fixture
+    def auth_app(self, clean_env):
+        provider = build_auth_provider(_config(**FAKE_AUTH))
+        mcp = FastMCP("auth-test", auth=provider)
+        return mcp.http_app()
+
+    async def test_protected_resource_metadata_served(self, auth_app):
+        """RFC 9728: /.well-known/oauth-protected-resource must resolve."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=auth_app), base_url="https://library.example.app"
+        ) as http:
+            response = await http.get("/.well-known/oauth-protected-resource/mcp")
+            assert response.status_code == 200
+            body = response.json()
+            assert "authorization_servers" in body
+
+    async def test_authorization_server_metadata_served(self, auth_app):
+        """RFC 8414 metadata advertises PKCE support (OAuth 2.1 requires S256)."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=auth_app), base_url="https://library.example.app"
+        ) as http:
+            response = await http.get("/.well-known/oauth-authorization-server")
+            assert response.status_code == 200
+            body = response.json()
+            assert "S256" in body.get("code_challenge_methods_supported", [])
+
+    async def test_mcp_endpoint_rejects_unauthenticated_requests(self, auth_app):
+        """Bearer-token enforcement: no token -> 401 with WWW-Authenticate."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=auth_app), base_url="https://library.example.app"
+        ) as http:
+            response = await http.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+            assert response.status_code == 401
+            assert "www-authenticate" in {k.lower() for k in response.headers}
+
+
+class TestHealthEndpoint:
+    async def test_health_route_is_public(self):
+        """Liveness probes must work without tokens (and expose nothing)."""
+        import server
+
+        app = server.mcp.http_app()
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as http:
+            response = await http.get("/health")
+            assert response.status_code == 200
+            assert response.json()["status"] == "ok"
+
+
+class TestEmailAllowlist:
+    """Authorization on top of authentication: only listed accounts pass."""
+
+    class _Token:
+        def __init__(self, email):
+            self.claims = {"email": email} if email else {}
+
+    @pytest.fixture
+    def middleware(self):
+        from auth import EmailAllowlistMiddleware
+
+        return EmailAllowlistMiddleware(["Owner@Example.com"])
+
+    async def test_allowed_email_passes(self, middleware, monkeypatch):
+        monkeypatch.setattr("auth.get_access_token", lambda: self._Token("owner@example.com"))
+
+        async def call_next(_ctx):
+            return "served"
+
+        assert await middleware.on_request(None, call_next) == "served"
+
+    async def test_unlisted_email_rejected(self, middleware, monkeypatch):
+        from fastmcp.exceptions import ToolError
+
+        monkeypatch.setattr("auth.get_access_token", lambda: self._Token("intruder@example.com"))
+
+        async def call_next(_ctx):  # pragma: no cover - must not be reached
+            raise AssertionError("request must not be served")
+
+        with pytest.raises(ToolError, match="not authorized"):
+            await middleware.on_request(None, call_next)
+
+    async def test_missing_email_claim_rejected(self, middleware, monkeypatch):
+        from fastmcp.exceptions import ToolError
+
+        monkeypatch.setattr("auth.get_access_token", lambda: self._Token(None))
+
+        async def call_next(_ctx):  # pragma: no cover
+            raise AssertionError("request must not be served")
+
+        with pytest.raises(ToolError, match="not authorized"):
+            await middleware.on_request(None, call_next)

--- a/virtual-library-mcp/tests/test_config.py
+++ b/virtual-library-mcp/tests/test_config.py
@@ -115,20 +115,16 @@ class TestServerConfig:
 
     def test_transport_validation(self):
         """Test transport mechanism validation."""
-        # MCP supports multiple transports
-        valid_transports = ["stdio", "streamable_http"]
-
-        for transport in valid_transports:
-            config = ServerConfig(transport=transport)
-            assert config.transport == transport
+        assert ServerConfig(transport="stdio").transport == "stdio"
+        assert ServerConfig(transport="http").transport == "http"
+        # Legacy spelling accepted but normalized to FastMCP 3's name.
+        assert ServerConfig(transport="streamable_http").transport == "http"
 
         # Invalid transports
         with pytest.raises(ValidationError):
-            ServerConfig(transport="http")  # Not a valid MCP transport
-        with pytest.raises(ValidationError):
             ServerConfig(transport="sse")  # SSE is deprecated
         with pytest.raises(ValidationError):
-            ServerConfig(transport="websocket")  # WebSocket is future transport
+            ServerConfig(transport="websocket")  # WebSocket is not a transport
 
     def test_port_validation(self):
         """Test HTTP port validation for Streamable HTTP transport."""


### PR DESCRIPTION
## Summary

**Stacked on #56.** The server becomes a remotely deployable OAuth 2.1 Protected Resource per the MCP 2025-11-25 authorization spec.

### Architecture
FastMCP's `GoogleProvider` implements the **OAuth Proxy** pattern: spec-compliant toward MCP clients (RFC 9728 PRM → RFC 8414 metadata → DCR/CIMD → Authorization Code + **PKCE S256**), bridged upstream to one fixed Google OAuth client. Real Google sign-in, zero per-client Google setup.

The HTTP transport runs **stateful** Streamable HTTP deliberately: sampling, elicitation, and notifications are server→client requests over the session's SSE stream. Deployment uses session affinity (next PR).

### Security posture — fails closed everywhere
- HTTP without auth **refuses to start** unless `ALLOW_INSECURE_HTTP=true` (localhost dev)
- Incomplete auth config fails startup naming the missing variables; `base_url` must be HTTPS (localhost exempt)
- **Email allowlist middleware** — authorization on top of authentication; without it, "authenticated" = any Google account. Set `VIRTUAL_LIBRARY_AUTH_ALLOWED_EMAILS=["you@gmail.com"]`
- Consent screen + CIMD enabled; rate-limiting middleware; secrets `repr=False`; `/health` exposes only `{"status": "ok"}`

### Security review
Ran a dedicated multi-pass branch security review (high-confidence bar): **no exploitable vulnerabilities**. Verified: path-confinement (resolve-then-check), SQL parameterization, no eval/exec/pickle, no secret logging, 401+`WWW-Authenticate` enforcement. Its one design note (any-Google-account auth) is addressed by the allowlist.

### Verification
- 15 new tests including live ASGI checks of the discovery endpoints, S256 advertisement, and tokenless-request rejection
- Live smoke test: `just dev-http` → `/health` ✅, real Streamable HTTP client listed 8 tools and searched the catalog
- `just test` ✅ 215 · `just lint` ✅ · `just typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)