### PR TITLE
Cloud Run deployment: Dockerfile, Terraform, deploy tooling

### DIFF
--- a/virtual-library-mcp/.dockerignore
+++ b/virtual-library-mcp/.dockerignore
@@ -1,0 +1,17 @@
+.venv/
+.git/
+.pytest_cache/
+.ruff_cache/
+htmlcov/
+__pycache__/
+*.pyc
+.env
+.env.local
+data/library.db
+data/*.db
+terraform/
+docs/
+examples/
+tests/
+.pre-commit-config.yaml
+.secrets.baseline

--- a/virtual-library-mcp/.gitignore
+++ b/virtual-library-mcp/.gitignore
@@ -223,3 +223,9 @@ Pipfile.lock
 # requirements-dev.txt
 type_annotation_analysis.md
 type_annotation_audit.md
+
+# Terraform
+terraform/.terraform/
+terraform/terraform.tfvars
+terraform/*.tfstate*
+terraform/.terraform.lock.hcl

--- a/virtual-library-mcp/Dockerfile
+++ b/virtual-library-mcp/Dockerfile
@@ -1,0 +1,55 @@
+# Virtual Library MCP Server — Cloud Run container
+#
+# Multi-stage build:
+#   builder: resolves dependencies with uv and seeds the SQLite database,
+#            so the image ships a ready-to-serve catalog (instant cold start,
+#            no startup seeding, deterministic demo data)
+#   runtime: slim image, non-root user, only the venv + app + seeded data
+#
+# The database is baked in and therefore PER-INSTANCE and EPHEMERAL: writes
+# (checkouts, imports) live until the instance is recycled. That is the
+# right trade-off for a demo catalog — swap SQLite for Cloud SQL when state
+# must survive. Session affinity keeps an MCP client on one instance.
+
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Dependency layer first for build caching.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Application code.
+COPY . .
+
+# Seed the catalog into the image (module mode keeps /app on sys.path).
+RUN .venv/bin/python -m database.seed
+
+# --------------------------------------------------------------------------
+
+FROM python:3.12-slim AS runtime
+
+# Run as an unprivileged user; SQLite needs write access to data/ for its
+# journal files (and demo writes), nothing else is writable.
+RUN groupadd --system app && useradd --system --gid app --home /app app
+
+WORKDIR /app
+
+COPY --from=builder --chown=root:root /app/.venv /app/.venv
+COPY --from=builder --chown=root:root /app /app
+RUN chown -R app:app /app/data
+
+USER app
+
+# Cloud Run injects PORT; default to 8080 for local docker runs.
+# The HTTP transport refuses to start without auth unless explicitly
+# overridden, so a misconfigured deployment fails closed.
+ENV VIRTUAL_LIBRARY_TRANSPORT=http \
+    VIRTUAL_LIBRARY_HTTP_HOST=0.0.0.0 \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+CMD ["/bin/sh", "-c", "VIRTUAL_LIBRARY_HTTP_PORT=${PORT:-8080} exec /app/.venv/bin/python server.py"]

--- a/virtual-library-mcp/Dockerfile
+++ b/virtual-library-mcp/Dockerfile
@@ -46,9 +46,16 @@ USER app
 # Cloud Run injects PORT; default to 8080 for local docker runs.
 # The HTTP transport refuses to start without auth unless explicitly
 # overridden, so a misconfigured deployment fails closed.
+#
+# HOME=/tmp: FastMCP's OAuth proxy persists dynamic client registrations
+# under ~/.local/share/fastmcp. The app user's home is read-only by
+# design, and on Cloud Run /tmp is a writable in-memory tmpfs. Stored
+# registrations are per-instance and ephemeral, which FastMCP handles:
+# clients simply re-register on first contact with a fresh instance.
 ENV VIRTUAL_LIBRARY_TRANSPORT=http \
     VIRTUAL_LIBRARY_HTTP_HOST=0.0.0.0 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    HOME=/tmp
 
 EXPOSE 8080
 

--- a/virtual-library-mcp/README.md
+++ b/virtual-library-mcp/README.md
@@ -1,206 +1,99 @@
 # Virtual Library MCP Server
 
-A comprehensive MCP (Model Context Protocol) server implementation that simulates a complete library management system. This server serves as both a learning tool and a reference implementation for MCP concepts.
+A complete MCP (Model Context Protocol) server simulating a library
+management system — built as a learning tool and a reference for the
+**full protocol surface, revision 2025-11-25**, on FastMCP 3.
 
-## 🚀 Quick Start
+Pairs with [mcp-client-learning](https://github.com/willtech3/mcp-client-learning),
+a from-scratch client that exercises everything below (including the
+OAuth 2.1 flow against the deployed server).
+
+## What it demonstrates
+
+| MCP feature | Where to see it |
+|---|---|
+| Resources + RFC 6570 templates | `library://books/list`, `library://books/{isbn}`, stats and recommendations |
+| Tools with real input/output schemas | all 8 tools — typed signatures, structured content |
+| Tool annotations + icons (SEP-973) | read-only/idempotent hints, data-URI SVG icons |
+| **Elicitation** (approval + enum select) | `checkout_book` (fines confirmation), `renew_membership` (term choice) |
+| **Sampling** (server-initiated LLM calls) | `generate_book_insights` |
+| **Tool-enabled sampling** (SEP-1577) | `similar_books` insight — the client's LLM searches our catalog |
+| **Background tasks** (SEP-1686) | `regenerate_catalog` (`task=optional`) |
+| Progress notifications | `bulk_import_books`, `regenerate_catalog` |
+| `resources/list_changed` notifications | maintenance mode hides/restores the recommendations resource |
+| Prompts | `book_recommendation_prompt`, `reading_plan_prompt`, `review_generator_prompt` |
+| **OAuth 2.1 + PKCE** (authorization spec) | Streamable HTTP transport, Google identity, email allowlist |
+| Logging + observability | server log notifications; Logfire middleware tracing |
+
+The catalog is real: 201 authors, 393 actual books with accurate
+metadata, and 24 months of simulated circulation where every statistic
+derives from the underlying records (see `database/seed_data/`).
+
+## Quick start
 
 ```bash
-# Install dependencies
-just install
-
-# Initialize database with sample data
-just db-init
-
-# Run the MCP server
-just dev
+just install     # dependencies (uv)
+just db-seed     # build the catalog (201 authors, 393 books, full history)
+just dev         # stdio transport - for Claude Desktop / local clients
+just dev-http    # Streamable HTTP on http://127.0.0.1:8080/mcp (no auth, local only)
 ```
 
-## 📋 Current Status
+Then, from the sibling client repo:
 
-### ✅ Implemented
+```bash
+mcp-client demo --server http://127.0.0.1:8080/mcp --anonymous
+```
 
-- **Phase 1**: Project setup and configuration ✅
-- **Phase 2**: Data models and database layer ✅
-  - Author, Book, Patron, and Circulation models
-  - Repository pattern with pagination
-  - 1200+ books, 120+ authors, 60+ patrons in seed data
-- **Phase 3**: Core MCP Implementation ✅ **COMPLETED**
-  - FastMCP 2.0 server initialization
-  - Basic Resources:
-    - `/books/list` - Browse catalog with pagination
-    - `/books/{isbn}` - Get book details by ISBN
-  - Advanced Resources with URI templates:
-    - `/books/by-author/{author_id}` - Books by specific author
-    - `/books/by-genre/{genre}` - Books in a genre
-    - `/patrons/{id}/history` - Patron borrowing history
-    - `/stats/popular` - Most borrowed books
-    - `/stats/genres` - Genre distribution
-    - `/stats/circulation` - Current circulation stats
-    - `/recommendations/{patron_id}` - Personalized recommendations
-  - Tools with validation:
-    - `search_catalog` - Full-text search with filters
-    - `checkout_book` - Create loan transactions
-    - `return_book` - Process returns with fine calculation
-    - `reserve_book` - Queue management for unavailable books
+…or see [docs/DEMO.md](docs/DEMO.md) for the guided live-demo script.
 
-### 🚧 Coming Next
+## Transports & security
 
-- **Phase 4**: Advanced MCP Features
-  - **Step 16**: Subscriptions (real-time availability updates)
-  - **Step 18**: Prompts (AI-powered book recommendations)
-  - **Step 20**: Progress notifications for long operations
+- **stdio** (default): local development, Claude Desktop integration.
+- **Streamable HTTP**: stateful sessions (sampling/elicitation/notifications
+  ride a per-session SSE stream). OAuth 2.1 with PKCE via Google identity,
+  plus an email allowlist for authorization. The server **fails closed**:
+  HTTP without auth requires an explicit local-dev opt-out.
 
-## 🏗️ Architecture
+Deployment to Google Cloud Run (Terraform, Secret Manager, least-privilege
+service account, session affinity) is covered in
+[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+
+## Architecture
 
 ```text
 virtual-library-mcp/
-├── server.py               # MCP server entry point
-├── config.py               # Configuration management
-├── models/                 # Pydantic data models
-│   ├── author.py           # Author model with validation
-│   ├── book.py             # Book model with ISBN validation
-│   ├── patron.py           # Library patron model
-│   └── circulation.py      # Checkout/return/reservation models
-├── database/               # Data access layer
-│   ├── schema.py           # SQLAlchemy models
-│   ├── session.py          # Database session management
-│   └── *_repository.py     # Repository implementations
-├── resources/              # MCP resource implementations
-├── tools/                  # MCP tool implementations
-├── prompts/                # MCP prompt implementations
-├── data/                   # Data files and utilities
-├── tests/                  # Comprehensive test suite
-├── docs/                   # Project documentation
-└── justfile               # Task automation
+├── server.py               # FastMCP 3 server, transport selection, health route
+├── auth.py                 # OAuth 2.1 provider + email-allowlist middleware
+├── config.py               # pydantic-settings; fail-closed auth validation
+├── icons.py                # SEP-973 icons (inline SVG data URIs)
+├── models/                 # Pydantic domain models
+├── database/               # SQLAlchemy schema, repositories, seed simulator
+│   └── seed_data/          # curated real-book catalog (JSON)
+├── resources/              # MCP resources (register(mcp) per package)
+├── tools/                  # MCP tools - typed functions
+├── prompts/                # MCP prompts
+├── observability/          # Logfire middleware + metrics
+├── terraform/              # Cloud Run deployment (see docs/DEPLOYMENT.md)
+└── tests/                  # protocol-path tests via the in-memory client
 ```
 
-## 🛠️ Development
-
-### Prerequisites
-
-- Python 3.12+
-- uv (package manager)
-- just (task runner)
-
-### Common Tasks
+## Development
 
 ```bash
-just test         # Run test suite
-just lint         # Check code style
-just typecheck    # Run type checking
-just format       # Format code
-just dev-debug    # Run with debug logging
+just test         # pytest (in-memory MCP client tests)
+just lint         # ruff
+just typecheck    # pyright
+just check        # all gates
+just samples      # regenerate bulk-import sample files
 ```
 
-### Testing the Server
+Tests run against the real server through FastMCP's in-memory client, so
+they exercise actual protocol behavior: schema validation, elicitation
+round-trips, sampling handlers, progress, and notifications.
 
-The server uses stdio transport and expects JSON-RPC messages:
+## Spec version note
 
-```bash
-# Send an initialization request
-echo '{"jsonrpc": "2.0", "method": "initialize", "params": {"protocolVersion": "1.0"}, "id": 1}' | just dev
-```
-
-## 📚 MCP Features Demonstrated
-
-1. **Resources** ✅
-   - Browse library catalog with pagination and filtering
-   - View book details by ISBN  
-   - Dynamic URI templates for author/genre filtering
-   - Patron history and circulation statistics
-   - Personalized book recommendations
-   - Popular books and genre distribution stats
-
-2. **Tools** ✅
-   - `search_catalog` - Full-text search with genre/author filters
-   - `checkout_book` - Create loans with validation
-   - `return_book` - Process returns and calculate fines
-   - `reserve_book` - Manage reservation queues
-
-3. **Prompts** (Phase 4 - Coming Soon)
-   - Get personalized recommendations
-   - Generate reading plans
-
-4. **Subscriptions** (Phase 4 - Coming Soon)
-   - Real-time availability updates
-   - Reservation notifications
-
-## 🔍 Code Highlights
-
-- **Type Safety**: Comprehensive type annotations with Pydantic
-- **Error Handling**: MCP-compliant error responses
-- **Testing**: 100+ tests with fixtures
-- **Documentation**: Extensive inline documentation explaining MCP concepts
-
-## 🔄 Async/Sync Architecture Pattern
-
-### Understanding the Mixed Async/Sync Approach
-
-This MCP server uses a specific pattern that might seem unusual at first: **async handlers with synchronous database operations**. This is intentional and correct for our use case.
-
-#### Why Async Handlers?
-
-MCP protocol and FastMCP require async handlers because:
-- The protocol layer needs non-blocking I/O for handling multiple concurrent requests
-- Long-running operations shouldn't block other requests
-- Future operations might need async capabilities (external APIs, etc.)
-
-#### Why Sync Database Operations?
-
-We use synchronous SQLAlchemy with SQLite because:
-- SQLite is a local, file-based database with fast operations
-- Async SQLite provides no performance benefit (still single-threaded)
-- Synchronous code is simpler to understand and debug
-- SQLAlchemy's sync API is more mature and well-documented
-
-#### The Pattern in Practice
-
-```python
-# MCP requires async handlers
-async def list_books_handler(
-    uri: str,
-    context: Context,
-    params: BookListParams | None = None,
-) -> dict[str, Any]:
-    # But we can use sync operations inside
-    with session_scope() as session:  # Sync context manager
-        repo = BookRepository(session)
-        result = repo.search(...)     # Sync database query
-        return result.model_dump()    # Return sync result from async function
-```
-
-#### Key Points
-
-1. **This is not a mistake** - Async functions can contain sync code
-2. **Performance is fine** - SQLite operations are fast enough to not block
-3. **Future flexibility** - Easy to add async operations later if needed
-4. **Best of both worlds** - Protocol compliance + implementation simplicity
-
-#### When to Use Full Async
-
-You would use async all the way down when:
-- Using PostgreSQL/MySQL with async drivers (asyncpg, aiomysql)
-- Making external HTTP API calls
-- Dealing with slow I/O operations
-- Handling many concurrent database connections
-
-For a learning project with SQLite, the mixed approach provides the best balance of correctness and simplicity.
-
-## 📖 Learning Resources
-
-- See `src/server.py` for detailed MCP protocol explanations
-- Check `docs/DEVELOPMENT.md` for development workflow
-- Review test files for usage examples
-
-## 🤝 Contributing
-
-This is a learning project. Feel free to:
-
-- Report issues
-- Suggest improvements
-- Add new MCP features
-- Improve documentation
-
-## 📄 License
-
-Part of the MCP Learning Repository - see parent directory for license details.
+This server targets MCP revision **2025-11-25** (current). The 2026-07-28
+release candidate deprecates sampling/roots/logging and removes the
+initialize handshake; this repo intentionally stays on the current
+revision — those features are core learning material here.

--- a/virtual-library-mcp/docs/DEMO.md
+++ b/virtual-library-mcp/docs/DEMO.md
@@ -1,0 +1,112 @@
+# Live Demo Script
+
+A ~10-minute walkthrough that shows every MCP concept with the Virtual
+Library server and the [mcp-client-learning](https://github.com/willtech3/mcp-client-learning)
+client. Each step names the protocol feature on display.
+
+## Setup (before the demo)
+
+```bash
+# Terminal 1 - server (this repo)
+just db-seed && just dev-http
+
+# Terminal 2 - client (sibling repo)
+export ANTHROPIC_API_KEY=...   # for the sampling steps
+```
+
+For the OAuth variant, run against the Cloud Run deployment instead and
+drop `--anonymous` — the browser sign-in IS the demo of the
+authorization spec.
+
+## The script
+
+**1. Discovery — "the server describes itself"**
+
+```bash
+mcp-client tools --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+Point out: real parameter schemas per tool (an LLM can call these
+correctly without guessing), read-only/idempotent annotations, icons.
+
+**2. Structured search — "tools return data, not just prose"**
+
+```bash
+mcp-client call search_catalog --args '{"genre": "Dystopian", "available_only": true}' \
+  --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+Point out: the `structured` panel matches the tool's published
+outputSchema. Try `{"query": "dune"}` too — it's a real catalog.
+
+**3. Resources — "read-only data with URIs"**
+
+```bash
+mcp-client read "library://stats/popular/365/5" --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+Point out: *Atomic Habits* and *Fahrenheit 451* top the charts because
+the seeded circulation actually borrowed them more — stats derive from
+records, nothing is hard-coded.
+
+**4. Elicitation — "the server asks YOU mid-tool-call"**
+
+```bash
+mcp-client call renew_membership --args '{"patron_id": "patron_00002"}' \
+  --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+The terminal prompts for a renewal term (enum elicitation, SEP-1330).
+Then show the approval variant: pick a patron with outstanding fines
+(read `library://patrons/by-status/active` and look for
+`outstanding_fines > 0`), check out any available book for them, and
+decline the confirmation — the checkout aborts cleanly.
+
+**5. Sampling — "the server borrows YOUR Claude"**
+
+```bash
+mcp-client call generate_book_insights \
+  --args '{"isbn": "<isbn from step 2>", "insight_type": "summary"}' \
+  --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+The client shows the sampling request and asks permission — the human
+controls the spend. Then run `insight_type: "similar_books"`: that one
+hands Claude a catalog-search tool (SEP-1577), so its recommendations
+cite books this library actually holds.
+
+**6. Progress — "long operations stream status"**
+
+```bash
+mcp-client call bulk_import_books --args '{"file_path": "samples/books_medium.csv"}' \
+  --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+140 real books import with batch-by-batch progress and an ETA.
+
+**7. Notifications + tasks — "the catalog goes into maintenance mode"**
+
+```bash
+mcp-client call regenerate_catalog --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+Point out: progress across four stages, and the recommendations resource
+disappears/reappears (`resources/list_changed`) during the rebuild. The
+tool is also task-capable (SEP-1686) for clients that poll.
+
+**Or run it all at once:**
+
+```bash
+mcp-client demo --server http://127.0.0.1:8080/mcp --anonymous
+```
+
+## Talking points if asked
+
+- **Why is HTTP stateful?** Sampling/elicitation are server→client
+  requests; they need a session stream. That's why Cloud Run runs with
+  session affinity.
+- **Where's the auth?** OAuth 2.1 + PKCE per the MCP authorization spec;
+  the client implements discovery → registration → PKCE from scratch
+  (`mcp_client/oauth.py` in the sibling repo is heavily annotated).
+- **Is the data real?** 201 real authors, 393 real books, simulated
+  circulation with verified invariants (`tests/test_seed_data.py`).

--- a/virtual-library-mcp/docs/DEPLOYMENT.md
+++ b/virtual-library-mcp/docs/DEPLOYMENT.md
@@ -1,0 +1,117 @@
+# Deploying to Google Cloud Run
+
+This guide takes the Virtual Library MCP Server from your laptop to a
+public, OAuth-protected Streamable HTTP endpoint on Cloud Run.
+
+## Why Cloud Run
+
+For a containerized MCP server on GCP, Cloud Run is the right primitive:
+serverless containers with scale-to-zero (≈ free when idle), native HTTPS,
+SSE streaming support, and per-revision rollouts — without cluster
+management (GKE) or VM patching (GCE). The two constraints that matter for
+MCP are handled explicitly:
+
+| MCP property | Cloud Run answer |
+|---|---|
+| Stateful sessions (sampling/elicitation/notifications ride a session SSE stream) | `session_affinity = true` + small `max_instances` |
+| Demo SQLite baked into the image (per-instance, ephemeral) | acceptable for a demo; swap to Cloud SQL for durable writes |
+
+## Architecture
+
+```
+MCP client ──OAuth 2.1 + PKCE──> Cloud Run (virtual-library-mcp)
+   │                                 │ validates bearer tokens (GoogleProvider)
+   │<──discovery, tokens─────────────│ email allowlist middleware
+   │                                 │ SQLite catalog (baked into image)
+   └──sign-in──> Google OAuth <──────┘ client secret from Secret Manager
+```
+
+Identity is enforced **in the application** (OAuth 2.1 resource server +
+email allowlist), not at Cloud Run's IAM layer — MCP clients can't speak
+IAM, but they can speak the MCP authorization spec. The platform invoker
+is therefore public while the app fails closed.
+
+## Prerequisites
+
+- `gcloud` CLI authenticated (`gcloud auth login` and
+  `gcloud auth application-default login`)
+- `terraform` >= 1.7, `docker`
+- A GCP project with billing enabled
+
+## Step 1 — Bootstrap the infrastructure
+
+```bash
+cd virtual-library-mcp/terraform
+cp terraform.tfvars.example terraform.tfvars   # fill in project_id + allowed emails
+terraform init
+terraform apply -var deploy_service=false      # APIs, registry, secret, SA
+```
+
+The bootstrap apply prints `base_url` — Cloud Run URLs are deterministic
+(`https://<service>-<project-number>.<region>.run.app`), so the URL is
+known **before** anything is deployed. That's what makes Step 2 possible
+now instead of after a throwaway deploy.
+
+## Step 2 — Create the Google OAuth client (one-time, manual)
+
+Terraform cannot create standard OAuth clients (a GCP API limitation), so
+this is the one console step:
+
+1. Console → **APIs & Services → OAuth consent screen**: configure
+   (External, add yourself as a test user is fine for a demo).
+2. **APIs & Services → Credentials → Create credentials → OAuth client ID**:
+   - Application type: **Web application**
+   - Authorized redirect URI: `<base_url>/auth/callback`
+3. Copy the client ID into `terraform.tfvars`
+   (`google_oauth_client_id = "..."`).
+4. Store the client secret in Secret Manager — never in a file:
+
+```bash
+just secret-set     # prompts for the secret, pipes it to gcloud
+```
+
+## Step 3 — Build, push, deploy
+
+```bash
+just docker-push    # builds the image and pushes to Artifact Registry
+cd terraform && terraform apply    # deploys the Cloud Run service
+```
+
+## Step 4 — Verify
+
+```bash
+curl "$(terraform -chdir=terraform output -raw base_url)/health"
+# {"status":"ok","service":"virtual-library"}
+
+curl -i "$(terraform -chdir=terraform output -raw mcp_endpoint)" -X POST \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+# HTTP/2 401 + WWW-Authenticate: Bearer ... (auth is enforced)
+```
+
+Then connect a real MCP client (the `mcp-client-learning` sibling repo
+implements the full discovery → registration → PKCE flow) and sign in with
+an allowlisted Google account.
+
+## Security checklist
+
+- [x] OAuth 2.1 + PKCE (S256); tokens validated on every request
+- [x] Email allowlist (`auth_allowed_emails`) — authorization, not just authentication
+- [x] Client secret only in Secret Manager; read by a dedicated least-privilege SA
+- [x] No secrets in Terraform state (secret *container* managed, value out-of-band)
+- [x] Server fails closed: refuses unauthenticated HTTP, refuses incomplete auth config
+- [x] Rate limiting middleware; non-root container; bulk-import path confinement
+- [ ] Optional: Cloud Armor / Identity-Aware Proxy in front for defense in depth
+
+## Operational notes
+
+- **Writes are per-instance and ephemeral.** The SQLite catalog is baked
+  into the image; checkouts vanish when an instance recycles. That's
+  intentional for a self-resetting demo. For durable state: Cloud SQL
+  (Postgres) + the SQLAlchemy URL in config.
+- **Costs.** Scale-to-zero + `cpu_idle` keeps an idle demo at ~$0/month;
+  Secret Manager and Artifact Registry are pennies.
+- **Logs.** `gcloud run services logs read virtual-library-mcp --region=<region>`;
+  Logfire tracing activates automatically when `LOGFIRE_TOKEN` is set.
+- **Updating.** `just docker-push && terraform -chdir=terraform apply`
+  (use `image_tag` for immutable tags if you outgrow `latest`).

--- a/virtual-library-mcp/justfile
+++ b/virtual-library-mcp/justfile
@@ -245,6 +245,50 @@ docs-serve:
     @echo "🌐 Serving documentation locally..."
     @echo "📝 Documentation serving will be implemented in Phase 5"
 
+# === DEPLOYMENT (Google Cloud Run) ===
+# Full walkthrough: docs/DEPLOYMENT.md
+
+# Build the container image locally
+docker-build:
+    @echo "🐳 Building container image..."
+    docker build -t virtual-library-mcp:local .
+
+# Run the container locally (no auth, localhost only)
+docker-run: docker-build
+    @echo "🐳 Running on http://127.0.0.1:8080/mcp (insecure local mode)"
+    docker run --rm -p 8080:8080 \
+        -e VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP=true \
+        virtual-library-mcp:local
+
+# Build and push the image to Artifact Registry (uses terraform outputs)
+docker-push:
+    @echo "🚀 Building and pushing $(terraform -chdir=terraform output -raw image)"
+    gcloud auth configure-docker $(terraform -chdir=terraform output -raw image | cut -d/ -f1) --quiet
+    docker build --platform linux/amd64 -t $(terraform -chdir=terraform output -raw image) .
+    docker push $(terraform -chdir=terraform output -raw image)
+
+# Store the Google OAuth client secret in Secret Manager (prompts; no shell history)
+secret-set:
+    @echo "🔐 Paste the Google OAuth client secret (input hidden):"
+    @stty -echo; read SECRET; stty echo; echo; \
+        printf '%s' "$$SECRET" | gcloud secrets versions add \
+        $(terraform -chdir=terraform output -raw oauth_secret_name) --data-file=-
+    @echo "✅ Secret version added"
+
+# Terraform shortcuts
+tf-init:
+    terraform -chdir=terraform init
+
+tf-plan:
+    terraform -chdir=terraform plan
+
+tf-apply:
+    terraform -chdir=terraform apply
+
+# Bootstrap apply: everything except the Cloud Run service itself
+tf-bootstrap:
+    terraform -chdir=terraform apply -var deploy_service=false
+
 # === PRODUCTION ===
 
 # Build distribution package

--- a/virtual-library-mcp/terraform/apis.tf
+++ b/virtual-library-mcp/terraform/apis.tf
@@ -1,0 +1,13 @@
+# GCP APIs the deployment depends on.
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "run.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "secretmanager.googleapis.com",
+    "iam.googleapis.com",
+  ])
+
+  service            = each.key
+  disable_on_destroy = false
+}

--- a/virtual-library-mcp/terraform/cloudrun.tf
+++ b/virtual-library-mcp/terraform/cloudrun.tf
@@ -1,0 +1,124 @@
+# The Cloud Run service.
+#
+# Two deliberate, documented choices:
+#
+# 1. SESSION AFFINITY ON, SMALL MAX INSTANCES. MCP's Streamable HTTP
+#    transport here is stateful — sampling, elicitation, and notifications
+#    are server->client requests riding the session's SSE stream, and the
+#    demo's SQLite catalog is per-instance. Affinity pins a client to one
+#    instance; the small cap keeps behavior predictable. Stateless wide
+#    scaling would require externalizing sessions and the database.
+#
+# 2. PUBLIC INVOKER, AUTH AT THE APP LAYER. MCP clients authenticate with
+#    OAuth 2.1 bearer tokens validated by the server itself (plus the
+#    email allowlist). Cloud Run's IAM-based invoker auth can't speak the
+#    MCP authorization flow, so the platform layer stays open and the
+#    application enforces identity. The app fails closed if misconfigured.
+
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
+locals {
+  # Cloud Run deterministic URL — knowable BEFORE the first deploy, which
+  # is what lets the OAuth client be registered ahead of time.
+  base_url = "https://${var.service_name}-${data.google_project.current.number}.${var.region}.run.app"
+}
+
+resource "google_cloud_run_v2_service" "server" {
+  count = var.deploy_service ? 1 : 0
+
+  name                = var.service_name
+  location            = var.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.run_service.email
+    session_affinity                 = true
+    max_instance_request_concurrency = 40
+
+    scaling {
+      min_instance_count = 0 # scale to zero: free when idle
+      max_instance_count = var.max_instances
+    }
+
+    containers {
+      image = local.image
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        cpu_idle = true # CPU only during requests (cheapest tier)
+      }
+
+      env {
+        name  = "VIRTUAL_LIBRARY_TRANSPORT"
+        value = "http"
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_HTTP_HOST"
+        value = "0.0.0.0"
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_AUTH_ENABLED"
+        value = "true"
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_BASE_URL"
+        value = local.base_url
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_GOOGLE_CLIENT_ID"
+        value = var.google_oauth_client_id
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_AUTH_ALLOWED_EMAILS"
+        value = jsonencode(var.auth_allowed_emails)
+      }
+      env {
+        name = "VIRTUAL_LIBRARY_GOOGLE_CLIENT_SECRET"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.oauth_client_secret.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      startup_probe {
+        http_get {
+          path = "/health"
+        }
+        initial_delay_seconds = 2
+        period_seconds        = 3
+        failure_threshold     = 10
+      }
+
+      liveness_probe {
+        http_get {
+          path = "/health"
+        }
+        period_seconds = 30
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_secret_manager_secret_iam_member.service_can_read,
+  ]
+}
+
+# Platform-layer access is public; identity is enforced by the app's
+# OAuth 2.1 layer (see the header comment).
+resource "google_cloud_run_v2_service_iam_member" "public_invoker" {
+  count = var.deploy_service ? 1 : 0
+
+  name     = google_cloud_run_v2_service.server[0].name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/virtual-library-mcp/terraform/outputs.tf
+++ b/virtual-library-mcp/terraform/outputs.tf
@@ -1,0 +1,28 @@
+output "base_url" {
+  description = <<-EOT
+    The service's deterministic URL. Available even before the service is
+    deployed — use it to create the Google OAuth client:
+      Authorized redirect URI: <base_url>/auth/callback
+  EOT
+  value = local.base_url
+}
+
+output "mcp_endpoint" {
+  description = "URL MCP clients connect to"
+  value       = "${local.base_url}/mcp"
+}
+
+output "image" {
+  description = "Image reference `just docker-push` builds and pushes"
+  value       = local.image
+}
+
+output "oauth_secret_name" {
+  description = "Secret Manager secret that must hold the OAuth client secret"
+  value       = google_secret_manager_secret.oauth_client_secret.secret_id
+}
+
+output "service_account" {
+  description = "Service account the Cloud Run service runs as"
+  value       = google_service_account.run_service.email
+}

--- a/virtual-library-mcp/terraform/registry.tf
+++ b/virtual-library-mcp/terraform/registry.tf
@@ -1,0 +1,14 @@
+# Artifact Registry repository for the server image.
+
+resource "google_artifact_registry_repository" "images" {
+  repository_id = "mcp-servers"
+  location      = var.region
+  format        = "DOCKER"
+  description   = "Container images for MCP servers"
+
+  depends_on = [google_project_service.apis]
+}
+
+locals {
+  image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.images.repository_id}/${var.service_name}:${var.image_tag}"
+}

--- a/virtual-library-mcp/terraform/secrets.tf
+++ b/virtual-library-mcp/terraform/secrets.tf
@@ -1,0 +1,22 @@
+# Secret Manager: the Google OAuth client secret.
+#
+# Terraform creates the secret CONTAINER only — the value is added
+# out-of-band (`just secret-set`) so it never touches Terraform state.
+# State files are not a safe place for credentials.
+
+resource "google_secret_manager_secret" "oauth_client_secret" {
+  secret_id = "${var.service_name}-google-oauth-client-secret"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Only the service's dedicated service account may read it.
+resource "google_secret_manager_secret_iam_member" "service_can_read" {
+  secret_id = google_secret_manager_secret.oauth_client_secret.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_service.email}"
+}

--- a/virtual-library-mcp/terraform/service-account.tf
+++ b/virtual-library-mcp/terraform/service-account.tf
@@ -1,0 +1,22 @@
+# Dedicated least-privilege service account for the Cloud Run service.
+#
+# Deliberately NOT the default compute SA (which carries Editor on many
+# projects). This account can write logs/metrics and read one secret —
+# nothing else.
+
+resource "google_service_account" "run_service" {
+  account_id   = "${var.service_name}-sa"
+  display_name = "Virtual Library MCP Cloud Run service"
+}
+
+resource "google_project_iam_member" "log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.run_service.email}"
+}
+
+resource "google_project_iam_member" "metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.run_service.email}"
+}

--- a/virtual-library-mcp/terraform/terraform.tfvars.example
+++ b/virtual-library-mcp/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+
+project_id = "your-gcp-project-id"
+region     = "us-central1"
+
+# From Google Cloud Console -> APIs & Services -> Credentials, after the
+# bootstrap apply prints the base_url (see DEPLOYMENT.md).
+google_oauth_client_id = "1234567890-abc.apps.googleusercontent.com"
+
+# Who may use the server. Strongly recommended for personal deployments.
+auth_allowed_emails = ["you@gmail.com"]

--- a/virtual-library-mcp/terraform/variables.tf
+++ b/virtual-library-mcp/terraform/variables.tf
@@ -1,0 +1,55 @@
+variable "project_id" {
+  description = "GCP project that hosts the service"
+  type        = string
+}
+
+variable "region" {
+  description = "Cloud Run region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "service_name" {
+  description = "Cloud Run service name (also the deterministic URL's first label)"
+  type        = string
+  default     = "virtual-library-mcp"
+}
+
+variable "image_tag" {
+  description = "Tag of the container image to deploy"
+  type        = string
+  default     = "latest"
+}
+
+variable "google_oauth_client_id" {
+  description = "Google OAuth client ID for the MCP server (create in Cloud Console)"
+  type        = string
+  default     = ""
+}
+
+variable "auth_allowed_emails" {
+  description = "Google accounts authorized to use the server (empty = any Google account)"
+  type        = list(string)
+  default     = []
+}
+
+variable "deploy_service" {
+  description = <<-EOT
+    Whether to deploy the Cloud Run service itself. Set to false for the
+    bootstrap apply (creates APIs, registry, secret, service account) that
+    must happen before the image is pushed and the OAuth secret is set.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "max_instances" {
+  description = <<-EOT
+    Maximum Cloud Run instances. Keep small: MCP sessions are stateful
+    (sampling/elicitation ride a session SSE stream) and the SQLite catalog
+    is per-instance, so this deployment relies on session affinity rather
+    than wide horizontal scale.
+  EOT
+  type        = number
+  default     = 2
+}

--- a/virtual-library-mcp/terraform/versions.tf
+++ b/virtual-library-mcp/terraform/versions.tf
@@ -1,0 +1,25 @@
+# Terraform and provider requirements.
+#
+# State is local by default — fine for a single-owner demo. For anything
+# shared, create a GCS bucket and uncomment the backend block.
+
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.30, < 8"
+    }
+  }
+
+  # backend "gcs" {
+  #   bucket = "your-tf-state-bucket"
+  #   prefix = "virtual-library-mcp"
+  # }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
## Summary

**Stacked on #57.** Makes the server deployable to Cloud Run with one console step and three commands.

### Why Cloud Run (your question about compute primitives)
For a stateful-session MCP server on GCP, Cloud Run remains the best fit: serverless containers, scale-to-zero (~$0 idle), native HTTPS + SSE streaming, no clusters to manage. The MCP-specific constraints are handled head-on: **session affinity + small max-instances** (sampling/elicitation ride per-session SSE streams) and the demo SQLite is baked per-instance (documented; Cloud SQL is the durable-writes upgrade path). GKE/GCE would add ops burden for zero benefit at this scale; Cloud Functions can't hold sessions.

### Design choices
- **Deterministic URL trick**: `https://<service>-<project#>.<region>.run.app` is computed in Terraform *before* anything deploys, so the Google OAuth client (the one manual console step — GCP has no API for standard OAuth clients) can be created first. No throwaway deploys.
- **Secrets never in TF state**: Terraform manages the Secret Manager *container*; `just secret-set` adds the value via hidden stdin.
- **Least privilege**: dedicated SA with `logging.logWriter`, `monitoring.metricWriter`, and `secretAccessor` on exactly one secret.
- **App-layer identity**: platform invoker is public because MCP clients can't speak Cloud IAM; OAuth 2.1 + email allowlist enforce identity, and the app fails closed if misconfigured.

### Verification
- `terraform validate` ✅
- Image built and smoke-tested: `/health` ✅, real Streamable HTTP MCP client listed 8 tools and searched the baked-in catalog against the running container ✅
- `just test` 215 ✅ · `just lint` ✅

### Deploy flow (docs/DEPLOYMENT.md)
```
just tf-bootstrap        # APIs, registry, secret, SA → prints base_url
# console: create OAuth client with <base_url>/auth/callback
just secret-set          # client secret → Secret Manager
just docker-push         # build + push image
just tf-apply            # service goes live, OAuth-protected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)