### PR TITLE
feat: add virtual library MCP Apps widgets

### DIFF
--- a/virtual-library-mcp/README.md
+++ b/virtual-library-mcp/README.md
@@ -24,6 +24,38 @@ draft authorization model (with a built-in demo authorization server).
 VIRTUAL_LIBRARY_TRANSPORT=http VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP=true uv run python server.py
 ```
 
+## MCP Apps demo
+
+The FastMCP protocol path includes two read-only MCP App tools:
+
+- `browse_catalog_app` renders a searchable, sortable catalog with inventory
+  metrics and selectable book details.
+- `library_dashboard_app` renders circulation metrics, genre activity, and a
+  popular-books table.
+
+Preview both tools in FastMCP's local AppBridge host:
+
+```bash
+just dev-apps
+```
+
+For ChatGPT Developer Mode, run the app-only server so a temporary tunnel does
+not expose the full server's circulation or administration tools:
+
+```bash
+just dev-apps-http
+# In another terminal:
+ngrok http 8001
+```
+
+In ChatGPT, enable **Settings → Security and login → Developer mode**, then open
+**Plugins** and use the plus button to create a developer-mode app. Set its MCP
+server URL to the tunnel's HTTPS URL followed by `/mcp`, for example
+`https://example.ngrok.app/mcp`. Refresh the app in ChatGPT after changing tool
+metadata. The app-only endpoint is stateless and contains only the two read-only
+UI tools; it still serves simulated data and is intended for short-lived
+development tunnels rather than permanent hosting.
+
 ## 🚀 Quick Start
 
 ```bash

--- a/virtual-library-mcp/apps_server.py
+++ b/virtual-library-mcp/apps_server.py
@@ -1,0 +1,37 @@
+"""App-only FastMCP entry point for local preview and ChatGPT Developer Mode.
+
+The full teaching server also registers these UI tools, but it exposes mutation
+and administration tools that should not sit behind an unauthenticated tunnel.
+This deliberately narrow server publishes only the read-only MCP Apps demos.
+"""
+
+from fastmcp import FastMCP
+
+from tools.apps import register
+
+mcp = FastMCP(
+    name="Virtual Library MCP Apps",
+    version="0.1.0",
+    instructions=(
+        "Use browse_catalog_app to visually explore books and "
+        "library_dashboard_app to show circulation and popularity. "
+        "Both tools are read-only demonstrations backed by simulated library data."
+    ),
+)
+register(mcp)
+
+
+def main() -> None:
+    """Run the app-only server on a local Streamable HTTP endpoint."""
+    mcp.run(
+        transport="http",
+        host="127.0.0.1",
+        port=8001,
+        path="/mcp",
+        stateless_http=True,
+        json_response=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/virtual-library-mcp/justfile
+++ b/virtual-library-mcp/justfile
@@ -64,6 +64,14 @@ dev-http-auth:
     @echo "   Requires VIRTUAL_LIBRARY_BASE_URL, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET in .env"
     VIRTUAL_LIBRARY_TRANSPORT=http VIRTUAL_LIBRARY_AUTH_ENABLED=true .venv/bin/python server.py
 
+# Preview MCP App tools in FastMCP's local AppBridge host
+dev-apps:
+    uv run fastmcp dev apps apps_server.py
+
+# Run only the read-only MCP App tools for temporary HTTPS tunneling
+dev-apps-http:
+    uv run python apps_server.py
+
 # === CODE QUALITY ===
 
 # Run all linting checks

--- a/virtual-library-mcp/pyproject.toml
+++ b/virtual-library-mcp/pyproject.toml
@@ -23,7 +23,10 @@ classifiers = [
 # Core dependencies for MCP server functionality
 dependencies = [
     # MCP framework (v3, targets protocol revision 2025-11-25)
-    "fastmcp[tasks]>=3.4,<4",
+    "fastmcp[apps,tasks]>=3.4,<4",
+    # FastMCP intentionally leaves Prefab's upper bound open; pin it for
+    # reproducible MCP App rendering while the UI package evolves quickly.
+    "prefab-ui==0.20.2",
 
     # MCP 2026-07-28 modern-protocol implementation (modern/ package)
     "pyjwt[crypto]>=2.9",

--- a/virtual-library-mcp/tests/tools/conftest.py
+++ b/virtual-library-mcp/tests/tools/conftest.py
@@ -31,12 +31,14 @@ from database.schema import (
 # Every tools module imports its session factory into its own namespace,
 # so each must be patched where it is *used*, not where it is defined.
 _SESSION_FACTORY_PATCHES = [
+    "tools.apps.session_scope",
     "tools.search.get_session",
     "tools.circulation.get_session",
     "tools.membership.get_session",
     "tools.bulk_import.session_scope",
     "tools.catalog_maintenance.session_scope",
     "tools.book_insights.session_scope",
+    "resources.stats.session_scope",
 ]
 
 

--- a/virtual-library-mcp/tests/tools/test_apps.py
+++ b/virtual-library-mcp/tests/tools/test_apps.py
@@ -1,0 +1,72 @@
+"""Protocol-level tests for the read-only MCP App tools."""
+
+import json
+
+import pytest
+from fastmcp import Client
+
+import apps_server
+import server
+
+
+@pytest.fixture
+async def client(library):
+    async with Client(server.mcp) as test_client:
+        yield test_client
+
+
+class TestAppDescriptors:
+    async def test_app_only_server_exposes_no_mutating_tools(self, library):
+        async with Client(apps_server.mcp) as app_client:
+            tools = {tool.name for tool in await app_client.list_tools()}
+
+        assert tools == {"browse_catalog_app", "library_dashboard_app"}
+
+    async def test_app_tools_publish_ui_metadata_and_safety_hints(self, client):
+        tools = {tool.name: tool for tool in await client.list_tools()}
+
+        for name in ("browse_catalog_app", "library_dashboard_app"):
+            descriptor = tools[name].model_dump(by_alias=True, exclude_none=True)
+            assert descriptor["annotations"] == {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": False,
+            }
+            assert descriptor["_meta"]["ui"]["resourceUri"].startswith("ui://")
+
+    async def test_prefab_renderer_resource_is_registered(self, client):
+        resources = await client.list_resources()
+        renderers = [resource for resource in resources if str(resource.uri).startswith("ui://")]
+
+        assert renderers
+        renderer = (await client.read_resource(renderers[0].uri))[0]
+        assert renderer.mimeType == "text/html;profile=mcp-app"
+
+
+class TestAppBehavior:
+    async def test_catalog_app_contains_filtered_book_data(self, client):
+        result = await client.call_tool(
+            "browse_catalog_app",
+            {"genre": "fiction", "availability": "available"},
+        )
+        payload = json.dumps(result.structured_content)
+
+        assert "The Available Book" in payload
+        assert "The Popular Book" not in payload
+        assert "Test Author" in payload
+
+    async def test_dashboard_contains_metrics_and_popular_books(self, client):
+        result = await client.call_tool(
+            "library_dashboard_app",
+            {"days": 30, "popular_limit": 5},
+        )
+        payload = json.dumps(result.structured_content)
+
+        assert "Virtual Library Dashboard" in payload
+        assert "The Popular Book" in payload
+        assert "Circulation rate" in payload
+
+    async def test_app_inputs_are_bounded(self, client):
+        with pytest.raises(Exception, match="validation"):
+            await client.call_tool("browse_catalog_app", {"limit": 0})

--- a/virtual-library-mcp/tools/__init__.py
+++ b/virtual-library-mcp/tools/__init__.py
@@ -33,6 +33,8 @@ from mcp.types import Icon, ToolAnnotations
 
 from icons import BOOK_ICON, CARD_ICON, MAINTENANCE_ICON, SEARCH_ICON, SPARKLE_ICON
 
+from . import apps
+from .apps import browse_catalog_app, library_dashboard_app
 from .book_insights import generate_book_insights
 from .bulk_import import bulk_import_books
 from .catalog_maintenance import regenerate_catalog
@@ -180,14 +182,17 @@ def register(mcp: FastMCP) -> None:
             tags=set(spec.tags),
             task=spec.task,
         )
+    apps.register(mcp)
 
 
 __all__ = [
     "TOOL_SPECS",
     "ToolSpec",
+    "browse_catalog_app",
     "bulk_import_books",
     "checkout_book",
     "generate_book_insights",
+    "library_dashboard_app",
     "regenerate_catalog",
     "register",
     "renew_membership",

--- a/virtual-library-mcp/tools/apps.py
+++ b/virtual-library-mcp/tools/apps.py
@@ -1,0 +1,252 @@
+"""Read-only MCP Apps for visually exploring the virtual library.
+
+FastMCP's ``app=True`` integration attaches the standard MCP Apps UI metadata,
+registers the shared ``text/html;profile=mcp-app`` renderer resource, and
+serializes each Prefab component tree into structured content. These tools are
+registered only on the FastMCP protocol path used by current MCP Apps hosts;
+the hand-built 2026-07-28 teaching transport remains framework-independent.
+"""
+
+from typing import Annotated, Any, Literal
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+from prefab_ui.actions import SetState
+from prefab_ui.app import PrefabApp
+from prefab_ui.components import (
+    H3,
+    Badge,
+    Card,
+    CardContent,
+    CardHeader,
+    Column,
+    DataTable,
+    DataTableColumn,
+    Grid,
+    Heading,
+    Metric,
+    Row,
+    Separator,
+    Small,
+    Text,
+)
+from prefab_ui.components.charts import BarChart, ChartSeries
+from prefab_ui.components.control_flow import If
+from prefab_ui.rx import STATE, Rx
+from pydantic import Field
+
+from database.author_repository import AuthorRepository
+from database.book_repository import BookRepository, BookSearchParams, BookSortOptions
+from database.repository import PaginationParams
+from database.session import session_scope
+from icons import BOOK_ICON, SPARKLE_ICON
+from resources.stats import (
+    get_circulation_stats_handler,
+    get_genre_distribution_handler,
+    get_popular_books_handler,
+)
+
+
+def _catalog_rows(
+    query: str | None,
+    genre: str | None,
+    available_only: bool,
+    limit: int,
+) -> tuple[list[dict[str, Any]], int]:
+    """Load display-ready catalog rows and the total matching count."""
+    query = query.strip() if query and query.strip() else None
+    genre = genre.strip().title() if genre and genre.strip() else None
+
+    with session_scope() as session:
+        books = BookRepository(session).search(
+            search_params=BookSearchParams(
+                query=query,
+                genre=genre,
+                available_only=available_only,
+            ),
+            pagination=PaginationParams(page=1, page_size=limit),
+            sort_by=BookSortOptions.TITLE,
+        )
+        author_repo = AuthorRepository(session)
+        author_names = {}
+        for book in books.items:
+            if book.author_id not in author_names:
+                author = author_repo.get_by_id(book.author_id)
+                author_names[book.author_id] = author.name if author else "Unknown author"
+
+    rows = [
+        {
+            "title": book.title,
+            "author": author_names[book.author_id],
+            "genre": book.genre,
+            "year": book.publication_year,
+            "availability": (
+                f"On shelf ({book.available_copies}/{book.total_copies})"
+                if book.available_copies
+                else f"Checked out (0/{book.total_copies})"
+            ),
+            "available_copies": book.available_copies,
+            "total_copies": book.total_copies,
+            "isbn": book.isbn,
+            "description": book.description or "No description is available for this title.",
+        }
+        for book in books.items
+    ]
+    return rows, books.total
+
+
+async def browse_catalog_app(
+    query: Annotated[
+        str | None,
+        Field(description="Optional title, author, description, or ISBN search", max_length=200),
+    ] = None,
+    genre: Annotated[
+        str | None,
+        Field(description="Optional exact genre filter, such as Science Fiction"),
+    ] = None,
+    availability: Annotated[
+        Literal["all", "available"],
+        Field(description="Show all titles or only titles with copies on the shelf"),
+    ] = "all",
+    limit: Annotated[
+        int,
+        Field(description="Maximum number of rows to display", ge=1, le=50),
+    ] = 30,
+) -> PrefabApp:
+    """Use this when the user wants to browse or visually search the book catalog."""
+    rows, total = _catalog_rows(query, genre, availability == "available", limit)
+    copies_on_shelf = sum(row["available_copies"] for row in rows)
+    genres_shown = len({row["genre"] for row in rows})
+
+    with PrefabApp(state={"selected": None}) as app, Column(gap=4, css_class="p-6"):
+        Heading("Virtual Library Catalog")
+        Text(
+            f"Showing {len(rows)} of {total} matching titles. "
+            "Search, sort, or select a row for details."
+        )
+
+        with Grid(columns=3, gap=4):
+            Metric(label="Matching titles", value=str(total))
+            Metric(label="Copies on shelf", value=str(copies_on_shelf))
+            Metric(label="Genres shown", value=str(genres_shown))
+
+        DataTable(
+            columns=[
+                DataTableColumn(key="title", header="Title", sortable=True),
+                DataTableColumn(key="author", header="Author", sortable=True),
+                DataTableColumn(key="genre", header="Genre", sortable=True),
+                DataTableColumn(key="year", header="Year", sortable=True),
+                DataTableColumn(key="availability", header="Availability", sortable=True),
+            ],
+            rows=rows,
+            search=True,
+            on_row_click=SetState("selected", Rx("$event")),
+        )
+
+        with If(STATE.selected), Card():
+            with CardHeader(), Row(gap=2, align="center"):
+                H3(Rx("selected.title"))
+                Badge(Rx("selected.genre"), variant="secondary")
+            with CardContent():
+                with Grid(columns=3, gap=4):
+                    with Column(gap=0):
+                        Small("Author")
+                        Text(Rx("selected.author"))
+                    with Column(gap=0):
+                        Small("ISBN")
+                        Text(Rx("selected.isbn"))
+                    with Column(gap=0):
+                        Small("Availability")
+                        Text(Rx("selected.availability"))
+                Separator()
+                Text(Rx("selected.description"))
+
+    return app
+
+
+async def library_dashboard_app(
+    days: Annotated[
+        int,
+        Field(description="Number of recent days to analyze", ge=1, le=365),
+    ] = 30,
+    popular_limit: Annotated[
+        int,
+        Field(description="Number of popular titles to display", ge=1, le=20),
+    ] = 10,
+) -> PrefabApp:
+    """Use this when the user wants a visual snapshot of books and circulation."""
+    circulation = await get_circulation_stats_handler()
+    genre_result = await get_genre_distribution_handler(str(days))
+    popular_result = await get_popular_books_handler(str(days), str(popular_limit))
+
+    genre_rows = list(genre_result["genres"][:8])
+    popular_rows = [
+        {
+            "rank": book["rank"],
+            "title": book["title"],
+            "author": book["author"],
+            "checkouts": book["checkout_count"],
+            "status": "Available" if book["currently_available"] else "Checked out",
+        }
+        for book in popular_result["books"]
+    ]
+
+    with PrefabApp() as app, Column(gap=4, css_class="p-6"):
+        Heading("Virtual Library Dashboard")
+        Text(f"Inventory and reader activity for the last {days} days.")
+
+        with Grid(columns=4, gap=4):
+            Metric(label="Titles", value=f"{circulation['total_books']:,}")
+            Metric(label="Copies on shelf", value=f"{circulation['available_copies']:,}")
+            Metric(label="Checked out", value=f"{circulation['checked_out_copies']:,}")
+            Metric(label="Circulation rate", value=f"{circulation['circulation_rate']}%")
+
+        BarChart(
+            data=genre_rows,
+            series=[ChartSeries(data_key="checkout_count", label="Checkouts")],
+            x_axis="genre",
+            show_legend=False,
+        )
+
+        Separator()
+        H3("Most borrowed books")
+        DataTable(
+            columns=[
+                DataTableColumn(key="rank", header="#", sortable=True),
+                DataTableColumn(key="title", header="Title", sortable=True),
+                DataTableColumn(key="author", header="Author", sortable=True),
+                DataTableColumn(key="checkouts", header="Checkouts", sortable=True),
+                DataTableColumn(key="status", header="Status", sortable=True),
+            ],
+            rows=popular_rows,
+            search=True,
+        )
+
+    return app
+
+
+def register(mcp: FastMCP) -> None:
+    """Register the UI tools on the FastMCP path used by MCP Apps hosts."""
+    annotations = ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+    mcp.tool(
+        browse_catalog_app,
+        app=True,
+        annotations=annotations,
+        icons=[BOOK_ICON],
+        tags={"app", "catalog"},
+    )
+    mcp.tool(
+        library_dashboard_app,
+        app=True,
+        annotations=annotations,
+        icons=[SPARKLE_ICON],
+        tags={"app", "analytics"},
+    )
+
+
+__all__ = ["browse_catalog_app", "library_dashboard_app", "register"]

--- a/virtual-library-mcp/uv.lock
+++ b/virtual-library-mcp/uv.lock
@@ -528,6 +528,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+apps = [
+    { name = "fastmcp-slim", extra = ["apps"] },
+]
 tasks = [
     { name = "fastmcp-slim", extra = ["tasks"] },
 ]
@@ -550,6 +553,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+apps = [
+    { name = "prefab-ui" },
+]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
@@ -1072,6 +1078,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prefab-ui"
+version = "0.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cyclopts" },
+    { name = "pydantic" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/99/4e61eb3d3f8b09bdaa28bda3c99971264555f486a485333cb8e6f56c7d8c/prefab_ui-0.20.2.tar.gz", hash = "sha256:4ac17ebf8ec1c5a918a188625837fc608157907430a59c4feb8adac80e01262b", size = 4118979, upload-time = "2026-06-03T02:13:49.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/d0/59b697dd5a44e632fcc4aba42ff5f88224df672ffea1f5e9a5a9e9e50698/prefab_ui-0.20.2-py3-none-any.whl", hash = "sha256:861d4914e4d9120996b4d5c6753788beeca433754d7bb3cfbd13f9dba7ea8e85", size = 1852274, upload-time = "2026-06-03T02:13:47.539Z" },
 ]
 
 [[package]]
@@ -1827,10 +1847,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "faker" },
-    { name = "fastmcp", extra = ["tasks"] },
+    { name = "fastmcp", extra = ["apps", "tasks"] },
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "logfire" },
+    { name = "prefab-ui" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -1852,10 +1873,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "faker", specifier = ">=40" },
-    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.4,<4" },
+    { name = "fastmcp", extras = ["apps", "tasks"], specifier = ">=3.4,<4" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "jsonschema", specifier = ">=4.21" },
     { name = "logfire", specifier = ">=4" },
+    { name = "prefab-ui", specifier = "==0.20.2" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pydantic-settings", specifier = ">=2.10" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },


### PR DESCRIPTION
## What
- add read-only catalog and circulation dashboard MCP App tools using FastMCP and Prefab UI
- add an app-only Streamable HTTP entry point for safer temporary Developer Mode tunnels
- add atomic `just dev-apps` and `just dev-apps-http` recipes, focused protocol tests, dependency locks, and setup documentation

## Why
This gives the educational server two small visual demonstrations for MCP Apps hosts while keeping the custom 2026-07-28 teaching transport framework-independent. The tunnel entry point deliberately exposes only the two read-only UI tools.

## Impact
- the existing FastMCP server gains `browse_catalog_app` and `library_dashboard_app`
- a separate app-only server can be previewed locally or connected to ChatGPT Developer Mode
- FastMCP installs its Apps extra and pins Prefab UI 0.20.2 for reproducible rendering

## Checks
- `just lint`
- `just test` — 607 passed
- `just typecheck` — 0 errors
- FastMCP AppBridge preview: catalog filtering, sorting, row details, metrics, dashboard chart, and popular-books table verified interactively
- ChatGPT Developer Mode enabled; final remote-app creation is pending a retry because ChatGPT's Plugins directory is currently returning failed fetches and not rendering its developer plus control