### PR TITLE
Chat-client-ready deployment: legacy discovery era + stateless legacy HTTP

### DIFF
--- a/virtual-library-mcp/config.py
+++ b/virtual-library-mcp/config.py
@@ -99,6 +99,21 @@ class ServerConfig(BaseSettings):
         pattern=r"^/[a-zA-Z0-9/_-]*$",
     )
 
+    http_stateless: bool = Field(
+        default=False,
+        description=(
+            "Run the LEGACY (FastMCP) protocol path without Mcp-Session-Id "
+            "sessions. Ephemeral compute (Cloud Run scale-to-zero) recycles "
+            "instances at will, and hosted chat clients are known to cache a "
+            "stale session id across server restarts and then fail hard — "
+            "stateless mode sidesteps that entirely. Trade-off: legacy "
+            "features that ride the session's server->client stream "
+            "(sampling, elicitation, subscriptions) stop working; today's "
+            "chat clients don't use them anyway. The modern (2026-07-28) "
+            "era is stateless by design and unaffected."
+        ),
+    )
+
     # === Authentication (OAuth 2.1, MCP 2025-11-25 authorization spec) ===
     # The server acts as an OAuth Protected Resource. FastMCP's GoogleProvider
     # implements the OAuth Proxy pattern: spec-compliant PRM metadata, dynamic
@@ -204,6 +219,23 @@ class ServerConfig(BaseSettings):
             "(SEP-2549). 0 = immediately stale."
         ),
         ge=0,
+    )
+
+    discovery_era: str = Field(
+        default="modern",
+        description=(
+            "Which protocol era's OAuth discovery documents own the SHARED "
+            "well-known paths (both RFC 9728 PRM forms and the host-root "
+            "RFC 8414 form). 'modern' (default): the 2026-07-28 era serves "
+            "them — right for local demos of the draft auth flow. 'legacy': "
+            "they fall through to the legacy (FastMCP/Google) OAuth stack — "
+            "required for interactive chat clients (Claude, ChatGPT), which "
+            "speak the legacy era and cannot onboard if discovery points at "
+            "the modern demo AS. The modern era stays reachable either way "
+            "via its path-inserted metadata form "
+            "(/.well-known/oauth-authorization-server/auth)."
+        ),
+        pattern=r"^(modern|legacy)$",
     )
 
     allowed_origins: list[str] = Field(
@@ -374,6 +406,16 @@ class ServerConfig(BaseSettings):
                 raise ValueError(
                     f"auth_enabled=true but missing required settings: {', '.join(missing)}"
                 )
+        if self.discovery_era == "legacy" and not self.auth_enabled:
+            # Ceding the shared well-knowns to the legacy era only makes
+            # sense when a legacy OAuth stack exists to serve them; without
+            # it those paths would just 404 and BOTH eras would lose
+            # discovery.
+            raise ValueError(
+                "discovery_era='legacy' requires auth_enabled=true (the "
+                "legacy OAuth stack is what serves the shared discovery "
+                "documents in that mode)"
+            )
         if self.modern_auth_enabled and not self.demo_as_enabled:
             # The modern resource-server path validates JWTs against an
             # authorization server's JWKS. This educational build bundles its

--- a/virtual-library-mcp/docs/DEPLOYMENT.md
+++ b/virtual-library-mcp/docs/DEPLOYMENT.md
@@ -62,13 +62,23 @@ protocol eras have authentication enabled.
   That is fine for this demo catalog (per-instance, self-resetting
   SQLite) and would be unacceptable for real data — this is exactly the
   kind of trade-off the deployment is meant to teach.
-- **Discovery shadowing:** both eras publish OAuth discovery documents,
-  and the modern era's routes win at `/.well-known/oauth-protected-resource*`
-  and `/.well-known/oauth-authorization-server`. Remote clients should
-  therefore speak the **modern** era (the sibling `mcp-client-learning`
-  repo does); the legacy era still *enforces* its Google bearer auth, but
-  its self-discovery documents are shadowed, so exercise the legacy OAuth
-  flow locally rather than against this deployment.
+- **Shared discovery paths — `discovery_era`:** both eras publish OAuth
+  discovery documents, but RFC 9728/8414 pin them to fixed well-known
+  locations, so one era must own the shared paths. The deployment sets
+  `discovery_era = "legacy"`: the Google OAuth stack serves
+  `/.well-known/oauth-protected-resource*` and the host-root
+  `/.well-known/oauth-authorization-server`, which is what lets
+  interactive chat clients (Claude, ChatGPT — legacy-era speakers)
+  complete discovery → registration → PKCE against this server. The
+  modern era keeps its collision-free path-inserted metadata form
+  (`/.well-known/oauth-authorization-server/auth`), so a modern client
+  configured with the AS issuer (`<base_url>/auth`) still authenticates.
+- **Stateless legacy path — `http_stateless = true`:** hosted chat
+  clients cache `Mcp-Session-Id` across server restarts and fail hard
+  when an ephemeral instance recycles. The deployed legacy era therefore
+  runs sessionless; the session-stream features (sampling, elicitation,
+  subscriptions) are local-development demos, and the modern era is
+  stateless by design.
 
 ## One-time setup
 
@@ -169,6 +179,30 @@ curl "$BASE_URL/.well-known/oauth-authorization-server/auth"
 Then connect a real client — the `mcp-client-learning` sibling repo
 implements the full modern discovery → CIMD registration → PKCE →
 bearer flow.
+
+## Testing in chat clients (remote MCP + Apps UI)
+
+State of the client world as of 2026-07-12 (verify against current docs —
+this moves fast):
+
+| Client | Remote MCP + OAuth | Protocol era | MCP Apps UI | Notes |
+|---|---|---|---|---|
+| Claude (web, Desktop, iOS/Android) | Custom connectors, OAuth 2.1 + PKCE + DCR/CIMD | Legacy (2025-11-25) | Yes (since 2026-01-26) | Free plan: 1 custom connector; connects from Anthropic's cloud |
+| ChatGPT (web) | Developer mode (Plus/Pro/Business+), OAuth incl. DCR/CIMD | Legacy (version header unconfirmed — log it) | Yes — native MCP Apps standard; `openai/outputTemplate` is a legacy alias | Dev-mode connectors are web-only; mobile needs a published app |
+| Anything speaking 2026-07-28 | — | Modern | — | No shipping chat client yet (spec finals 2026-07-28); use the sibling client repo or beta-SDK tools |
+
+- **Claude:** Settings → Connectors → *Add custom connector* → URL
+  `<base_url>/mcp`. Claude walks the legacy PRM (which `discovery_era =
+  "legacy"` hands to the Google OAuth stack), registers dynamically, runs
+  PKCE, and you sign in with an allowlisted Google account. The
+  `browse_catalog_app` / `library_dashboard_app` tools render as
+  interactive widgets in chat on desktop, web, and mobile.
+- **ChatGPT:** Settings → Apps & Connectors → Advanced → Developer mode,
+  then create a connector with the same `/mcp` URL and OAuth. Widgets use
+  FastMCP's standard MCP Apps metadata, which ChatGPT consumes natively.
+- **Modern era (2026-07-28):** chat clients can't exercise it yet. Verify
+  it remotely with the sibling client repo against the deployed endpoint
+  (AS issuer `<base_url>/auth`), or MCPJam / beta-SDK clients.
 
 ## Security checklist
 

--- a/virtual-library-mcp/modern/auth/__init__.py
+++ b/virtual-library-mcp/modern/auth/__init__.py
@@ -46,8 +46,10 @@ from modern.auth.metadata import (
     build_prm_routes,
     challenge_401,
     challenge_403,
+    filter_shared_discovery_routes,
     prm_url_for,
     prm_well_known_paths,
+    shared_discovery_paths,
 )
 
 
@@ -108,6 +110,8 @@ __all__ = [
     "build_prm_routes",
     "challenge_401",
     "challenge_403",
+    "filter_shared_discovery_routes",
     "prm_url_for",
     "prm_well_known_paths",
+    "shared_discovery_paths",
 ]

--- a/virtual-library-mcp/modern/auth/metadata.py
+++ b/virtual-library-mcp/modern/auth/metadata.py
@@ -125,6 +125,52 @@ def prm_url_for(canonical_resource_url: str) -> str:
     return f"{parts.scheme}://{parts.netloc}{prm_well_known_paths(canonical_resource_url)[0]}"
 
 
+def shared_discovery_paths(canonical_resource_url: str) -> set[str]:
+    """Well-known paths BOTH protocol eras want to serve — the dual-era rub.
+
+    A dual-era server has two authorization stories publishing discovery
+    documents, but RFC 9728 and RFC 8414 pin those documents to fixed
+    well-known locations, so exactly one era can own each path:
+
+    - both PRM forms (path-inserted and host-root fallback): the modern era
+      serves its own PRM here, and a legacy OAuth stack (e.g. FastMCP's
+      OAuth proxy) serves ITS protected-resource metadata at the very same
+      paths — the resource URI is the same ``/mcp`` endpoint in both eras.
+    - the host-root RFC 8414 form ``/.well-known/oauth-authorization-server``:
+      the demo AS serves it as a convenience fallback, and a legacy stack
+      whose issuer is the host root serves it as its PRIMARY metadata URL.
+
+    NOT shared — and deliberately excluded — is the path-inserted AS
+    metadata form (``/.well-known/oauth-authorization-server/auth``): the
+    demo AS issuer has a ``/auth`` path component, so RFC 8414 §3.1 gives it
+    a collision-free home of its own. That is what keeps the modern era
+    discoverable even when the legacy era owns every shared path: a client
+    told the issuer directly can still fetch metadata and run the flow.
+    """
+    return set(prm_well_known_paths(canonical_resource_url)) | {
+        "/.well-known/oauth-authorization-server"
+    }
+
+
+def filter_shared_discovery_routes(routes: list[Route], canonical_resource_url: str) -> list[Route]:
+    """Drop the shared well-known routes so they fall through to the legacy era.
+
+    The dual-era front door (:func:`modern.http.create_dual_era_app`) routes
+    a non-MCP path to the modern app only when the modern app registered it;
+    everything else goes legacy. So ceding a discovery document to the
+    legacy era is done by NOT registering it here — no special cases in the
+    router itself.
+
+    Used when ``discovery_era = "legacy"``: interactive chat clients that
+    speak the legacy protocol walk PRM -> AS metadata -> PKCE from the
+    shared paths, so the legacy OAuth stack must own them for those clients
+    to onboard at all. The modern era keeps every era-specific route (the
+    ``/auth/*`` endpoints and the path-inserted metadata form).
+    """
+    shared = shared_discovery_paths(canonical_resource_url)
+    return [route for route in routes if route.path not in shared]
+
+
 def build_prm_routes(
     *,
     canonical_resource_url: str,

--- a/virtual-library-mcp/server.py
+++ b/virtual-library-mcp/server.py
@@ -185,7 +185,13 @@ def build_modern_stack():
     challenge_401_fn = None
     challenge_403_fn = None
     if config.demo_as_enabled:
-        from modern.auth import build_demo_auth, challenge_401, challenge_403, prm_url_for
+        from modern.auth import (
+            build_demo_auth,
+            challenge_401,
+            challenge_403,
+            filter_shared_discovery_routes,
+            prm_url_for,
+        )
 
         base = config.base_url or f"http://{config.http_host}:{config.http_port}"
         routes, verifier, issuer = build_demo_auth(
@@ -193,6 +199,17 @@ def build_modern_stack():
             canonical_resource_url=config.canonical_url,
             auto_approve=config.demo_as_auto_approve,
         )
+        if config.discovery_era == "legacy":
+            # Cede the shared well-known paths (PRM + host-root AS metadata)
+            # to the legacy OAuth stack so legacy-era chat clients can
+            # onboard; the modern flow stays reachable via the demo AS's
+            # path-inserted metadata form. See config.discovery_era.
+            routes = filter_shared_discovery_routes(routes, config.canonical_url)
+            logger.info(
+                "Discovery era: legacy — shared well-known paths fall through "
+                "to the legacy OAuth stack; modern AS metadata remains at "
+                "/.well-known/oauth-authorization-server/auth"
+            )
         extra_routes.extend(routes)
         prm_url = prm_url_for(config.canonical_url)
         challenge_401_fn = partial(challenge_401, prm_url)
@@ -249,7 +266,10 @@ def _run_http_server() -> None:
     # sessions, GET SSE stream, and Google OAuth; the modern pipeline is
     # stateless (SEP-2575). Classification happens per POST.
     _dispatcher, _broker, modern_asgi = build_modern_stack()
-    legacy_asgi = mcp.http_app(path=config.http_path)
+    # stateless_http: see config.http_stateless — required for reliable
+    # operation behind ephemeral compute; hosted chat clients cache stale
+    # session ids across instance recycles and then wedge.
+    legacy_asgi = mcp.http_app(path=config.http_path, stateless_http=config.http_stateless)
     app = create_dual_era_app(modern_asgi, legacy_asgi, mcp_path=config.http_path)
 
     logger.info(

--- a/virtual-library-mcp/terraform/cloudrun.tf
+++ b/virtual-library-mcp/terraform/cloudrun.tf
@@ -88,6 +88,18 @@ resource "google_cloud_run_v2_service" "server" {
         }
       }
 
+      # Stateless legacy path + legacy-owned discovery: what interactive
+      # chat clients need from an ephemeral-compute deployment (see
+      # variables.tf for both stories).
+      env {
+        name  = "VIRTUAL_LIBRARY_HTTP_STATELESS"
+        value = tostring(var.http_stateless)
+      }
+      env {
+        name  = "VIRTUAL_LIBRARY_DISCOVERY_ERA"
+        value = var.discovery_era
+      }
+
       # --- MODERN era (2026-07-28) ---------------------------------------
       # Bearer validation on the modern protocol path, tokens issued by the
       # bundled educational AS (see variables.tf for the security caveat).

--- a/virtual-library-mcp/terraform/variables.tf
+++ b/virtual-library-mcp/terraform/variables.tf
@@ -89,3 +89,32 @@ variable "demo_as_auto_approve" {
   type        = bool
   default     = false
 }
+
+variable "discovery_era" {
+  description = <<-EOT
+    Which protocol era's OAuth discovery documents own the shared
+    well-known paths. "legacy" is right for a deployment that interactive
+    chat clients (Claude, ChatGPT) connect to — they speak the legacy era
+    and walk PRM -> AS metadata -> PKCE from those paths. The modern
+    (2026-07-28) era keeps its path-inserted metadata form either way.
+  EOT
+  type        = string
+  default     = "legacy"
+
+  validation {
+    condition     = contains(["modern", "legacy"], var.discovery_era)
+    error_message = "discovery_era must be \"modern\" or \"legacy\"."
+  }
+}
+
+variable "http_stateless" {
+  description = <<-EOT
+    Run the legacy (FastMCP) protocol path without Mcp-Session-Id sessions.
+    Strongly recommended on Cloud Run: scale-to-zero recycles instances,
+    and hosted chat clients are known to cache a stale session id across
+    restarts and then wedge. Costs the session-stream features (sampling,
+    elicitation, subscriptions) remotely — chat clients don't use them.
+  EOT
+  type        = bool
+  default     = true
+}

--- a/virtual-library-mcp/tests/modern/test_http.py
+++ b/virtual-library-mcp/tests/modern/test_http.py
@@ -1011,3 +1011,69 @@ class TestBufferedCancellation:
         # Nothing meaningful goes to the vanished client: no JSON-RPC bytes.
         bodies = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
         assert bodies == b""
+
+
+# ---------------------------------------------------------------------------
+# Discovery-era routing (dual-era front door + filtered discovery routes)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyDiscoveryEraRouting:
+    """End-to-end routing behavior behind ``discovery_era='legacy'``.
+
+    server.py filters the modern route set with
+    ``filter_shared_discovery_routes`` before building the modern app; the
+    dual-era front door then routes anything the modern app did NOT register
+    to the legacy app. Together that hands the shared well-known documents
+    to the legacy OAuth stack while every /auth/* endpoint and the
+    path-inserted AS metadata stay modern — chat clients (legacy era) and a
+    modern client that knows the issuer can BOTH authenticate.
+    """
+
+    BASE = "https://library.example.run.app"
+
+    def dual_app_with_legacy_discovery(self) -> tuple[Any, LegacyStubApp]:
+        from modern.auth import build_demo_auth, filter_shared_discovery_routes
+
+        routes, _verifier, _issuer = build_demo_auth(
+            base_url=self.BASE,
+            canonical_resource_url=f"{self.BASE}/mcp",
+        )
+        routes = filter_shared_discovery_routes(routes, f"{self.BASE}/mcp")
+        modern, _dispatcher = make_modern(extra_routes=routes)
+        legacy = LegacyStubApp()
+        return create_dual_era_app(modern, legacy), legacy
+
+    async def test_shared_well_knowns_fall_through_to_legacy(self):
+        app, legacy = self.dual_app_with_legacy_discovery()
+        async with make_client(app) as client:
+            for path in (
+                "/.well-known/oauth-protected-resource/mcp",
+                "/.well-known/oauth-protected-resource",
+                "/.well-known/oauth-authorization-server",
+            ):
+                response = await client.get(path)
+                assert response.json() == {"era": "legacy"}, path
+        assert [call["path"] for call in legacy.calls] == [
+            "/.well-known/oauth-protected-resource/mcp",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-authorization-server",
+        ]
+
+    async def test_modern_as_stays_reachable_at_path_inserted_form(self):
+        app, legacy = self.dual_app_with_legacy_discovery()
+        async with make_client(app) as client:
+            metadata = await client.get("/.well-known/oauth-authorization-server/auth")
+        # RFC 8414 path-inserted metadata is served by the modern app…
+        assert metadata.status_code == 200
+        assert metadata.json()["issuer"] == f"{self.BASE}/auth"
+        # …without ever touching the legacy app.
+        assert legacy.calls == []
+
+    async def test_auth_endpoints_stay_modern(self):
+        app, legacy = self.dual_app_with_legacy_discovery()
+        async with make_client(app) as client:
+            jwks = await client.get("/auth/jwks.json")
+        assert jwks.status_code == 200
+        assert "keys" in jwks.json()
+        assert legacy.calls == []

--- a/virtual-library-mcp/tests/modern/test_modern_auth.py
+++ b/virtual-library-mcp/tests/modern/test_modern_auth.py
@@ -363,3 +363,65 @@ class TestChallengeHeaders:
         # quoted-string escaping keeps the header parseable regardless.
         header = challenge_403("s", "http://h/prm", 'needs "write" access')
         assert 'error_description="needs \\"write\\" access"' in header
+
+
+class TestSharedDiscoveryFiltering:
+    """discovery_era='legacy' support: ceding shared well-knowns to FastMCP.
+
+    A dual-era server has TWO OAuth stacks that both want the fixed RFC
+    9728/8414 well-known locations. ``shared_discovery_paths`` names the
+    contested paths; ``filter_shared_discovery_routes`` removes them from
+    the modern route set so the dual-era front door lets them fall through
+    to the legacy app — that is how interactive chat clients (which speak
+    the legacy era) complete OAuth discovery against a deployed dual-era
+    server.
+    """
+
+    CANONICAL = "https://library.example.run.app/mcp"
+
+    def test_shared_paths_are_the_three_contested_locations(self):
+        from modern.auth import shared_discovery_paths
+
+        assert shared_discovery_paths(self.CANONICAL) == {
+            "/.well-known/oauth-protected-resource/mcp",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/oauth-authorization-server",
+        }
+
+    def test_filter_keeps_every_era_specific_route(self):
+        from modern.auth import build_demo_auth, filter_shared_discovery_routes
+
+        routes, _verifier, _issuer = build_demo_auth(
+            base_url="https://library.example.run.app",
+            canonical_resource_url=self.CANONICAL,
+        )
+        kept = {r.path for r in filter_shared_discovery_routes(routes, self.CANONICAL)}
+
+        # The path-inserted AS metadata form is the modern era's collision-
+        # free discovery home (RFC 8414 §3.1 path insertion) — it MUST stay,
+        # or a modern client pointed at the issuer could never bootstrap.
+        assert "/.well-known/oauth-authorization-server/auth" in kept
+        # The AS endpoints themselves are all under /auth and never contested.
+        assert {
+            "/auth/authorize",
+            "/auth/consent",
+            "/auth/token",
+            "/auth/register",
+            "/auth/jwks.json",
+        } <= kept
+
+    def test_filter_drops_exactly_the_shared_paths(self):
+        from modern.auth import (
+            build_demo_auth,
+            filter_shared_discovery_routes,
+            shared_discovery_paths,
+        )
+
+        routes, _verifier, _issuer = build_demo_auth(
+            base_url="https://library.example.run.app",
+            canonical_resource_url=self.CANONICAL,
+        )
+        before = {r.path for r in routes}
+        after = {r.path for r in filter_shared_discovery_routes(routes, self.CANONICAL)}
+
+        assert before - after == shared_discovery_paths(self.CANONICAL)

--- a/virtual-library-mcp/tests/test_config.py
+++ b/virtual-library-mcp/tests/test_config.py
@@ -309,3 +309,35 @@ class TestConfigurationScenarios:
         # Server can provide required protocol information
         assert config.server_info
         assert config.capabilities
+
+
+class TestDiscoveryEra:
+    """discovery_era decides which era owns the SHARED well-known paths.
+
+    A dual-era server has two OAuth stacks but RFC 9728/8414 pin discovery
+    documents to fixed locations — the config knob picks the owner, and the
+    validator refuses combinations that would leave discovery serving 404s.
+    """
+
+    def test_default_is_modern(self):
+        assert ServerConfig().discovery_era == "modern"
+
+    def test_legacy_requires_legacy_auth(self):
+        # Ceding the shared paths to a legacy OAuth stack that isn't enabled
+        # would give NEITHER era working discovery — fail closed at startup.
+        with pytest.raises(ValidationError, match="requires auth_enabled"):
+            ServerConfig(discovery_era="legacy", auth_enabled=False)
+
+    def test_legacy_with_legacy_auth_is_valid(self):
+        config = ServerConfig(
+            discovery_era="legacy",
+            auth_enabled=True,
+            base_url="https://library.example.run.app",
+            google_client_id="client-id",
+            google_client_secret="client-secret",
+        )
+        assert config.discovery_era == "legacy"
+
+    def test_invalid_value_rejected(self):
+        with pytest.raises(ValidationError):
+            ServerConfig(discovery_era="both")


### PR DESCRIPTION
## Summary
Makes the deployed dual-era server consumable by real chat clients (Claude custom connectors, ChatGPT developer mode), which speak the legacy era and onboard via the RFC 9728/8414 well-known documents.

- **`discovery_era` config** ('modern' default; deployment sets 'legacy'): the modern app cedes the three shared well-known paths to the FastMCP/Google OAuth stack; the modern demo AS stays reachable at its collision-free path-inserted metadata form. Fail-closed validator (legacy discovery requires legacy auth on).
- **`http_stateless` config** (false default; deployment sets true): sessionless legacy path — hosted chat clients cache stale `Mcp-Session-Id` across instance recycles and wedge on ephemeral compute.
- Terraform vars + Cloud Run env for both; DEPLOYMENT.md gains a client-compatibility matrix (2026-07-12) and Claude/ChatGPT connect steps.

## Test plan
- [x] 617 tests (10 new: shared-path enumeration, route filtering, dual-era fall-through routing, config validators), ruff, pyright clean
- [x] `terraform validate`
- [x] Live-verified: legacy PRM + AS metadata at shared paths, demo AS at `/.well-known/oauth-authorization-server/auth`, 401 from both eras

🤖 Generated with [Claude Code](https://claude.com/claude-code)