### PR TITLE
Persist OAuth clients across Cloud Run instances

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,17 @@ jobs:
             terraform apply -input=false -auto-approve -var deploy_service=false
           fi
 
+      # Existing deployments skip the prerequisite phase above. Materialize
+      # the two newly introduced secret containers before trying to seed their
+      # first versions. The final full apply remains authoritative for IAM,
+      # Firestore, and the Cloud Run service.
+      - name: Terraform apply — OAuth secret containers
+        working-directory: virtual-library-mcp/terraform
+        run: |
+          terraform apply -input=false -auto-approve \
+            -target=google_secret_manager_secret.oauth_jwt_signing_key \
+            -target=google_secret_manager_secret.oauth_storage_encryption_key
+
       # The MRTR requestState HMAC key is machine-generated: seed it once,
       # directly into Secret Manager, so it never exists in Terraform state
       # or GitHub. Subsequent runs see the version and skip.
@@ -140,6 +151,24 @@ jobs:
           else
             echo "Secret already seeded"
           fi
+
+      # FastMCP signs its own client-facing access tokens and encrypts DCR
+      # registrations/upstream tokens before writing them to Firestore. Seed
+      # stable, purpose-specific keys once so all instances and revisions can
+      # read the same OAuth state.
+      - name: Seed legacy OAuth persistence keys (first run only)
+        run: |
+          for SUFFIX in oauth-jwt-signing-key oauth-storage-encryption-key; do
+            NAME="${SERVICE_NAME}-${SUFFIX}"
+            if ! gcloud secrets versions list "$NAME" --filter="state=enabled" \
+                 --format="value(name)" --project "$PROJECT_ID" | grep -q .; then
+              echo "No enabled version for $NAME — seeding random key"
+              openssl rand -base64 48 | tr -d '\n' | \
+                gcloud secrets versions add "$NAME" --data-file=- --project "$PROJECT_ID"
+            else
+              echo "Secret $NAME already seeded"
+            fi
+          done
 
       # The Google OAuth client secret can only come from a human (Cloud
       # Console). Fail loudly with instructions rather than deploying a
@@ -195,6 +224,7 @@ jobs:
 
           echo "OAuth discovery documents..."
           curl --fail --silent "$BASE_URL/.well-known/oauth-protected-resource/mcp" >/dev/null
+          curl --fail --silent "$BASE_URL/.well-known/oauth-authorization-server" >/dev/null
           curl --fail --silent "$BASE_URL/.well-known/oauth-authorization-server/auth" >/dev/null
 
           echo "All smoke tests passed. MCP endpoint: $MCP_URL"

--- a/virtual-library-mcp/.env.sample
+++ b/virtual-library-mcp/.env.sample
@@ -36,6 +36,12 @@ VIRTUAL_LIBRARY_AUTH_ENABLED=false
 # VIRTUAL_LIBRARY_GOOGLE_CLIENT_ID=1234567890.apps.googleusercontent.com
 # VIRTUAL_LIBRARY_GOOGLE_CLIENT_SECRET=GOCSPX-...   # keep out of source control!
 
+# Cloud/serverless production: keep FastMCP OAuth registrations and tokens in
+# encrypted shared Firestore storage. Local development may leave these unset.
+# VIRTUAL_LIBRARY_LEGACY_OAUTH_FIRESTORE_PROJECT=your-gcp-project
+# VIRTUAL_LIBRARY_LEGACY_OAUTH_JWT_SIGNING_KEY=generated-secret
+# VIRTUAL_LIBRARY_LEGACY_OAUTH_STORAGE_ENCRYPTION_KEY=generated-secret
+
 # Authorization allowlist (JSON array): which Google accounts may use the
 # server. Empty/unset = any authenticated Google account. Recommended for
 # personal deployments:

--- a/virtual-library-mcp/Dockerfile
+++ b/virtual-library-mcp/Dockerfile
@@ -47,11 +47,10 @@ USER app
 # The HTTP transport refuses to start without auth unless explicitly
 # overridden, so a misconfigured deployment fails closed.
 #
-# HOME=/tmp: FastMCP's OAuth proxy persists dynamic client registrations
-# under ~/.local/share/fastmcp. The app user's home is read-only by
-# design, and on Cloud Run /tmp is a writable in-memory tmpfs. Stored
-# registrations are per-instance and ephemeral, which FastMCP handles:
-# clients simply re-register on first contact with a fresh instance.
+# HOME=/tmp gives libraries a writable scratch home while the app user's real
+# home stays read-only. Production OAuth state does NOT live here: Terraform
+# configures FastMCP with encrypted Firestore storage so DCR registrations and
+# tokens survive scale-to-zero, revision changes, and multiple instances.
 ENV VIRTUAL_LIBRARY_TRANSPORT=http \
     VIRTUAL_LIBRARY_HTTP_HOST=0.0.0.0 \
     PYTHONUNBUFFERED=1 \

--- a/virtual-library-mcp/README.md
+++ b/virtual-library-mcp/README.md
@@ -110,7 +110,8 @@ development tunnels rather than permanent hosting.
 
 Deployment to Google Cloud Run happens exclusively through GitHub Actions
 (keyless Workload Identity Federation, Terraform with remote state,
-Secret Manager, least-privilege service accounts, session affinity) —
+Secret Manager, encrypted Firestore-backed OAuth state, least-privilege
+service accounts, session affinity) —
 covered in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 ## Architecture

--- a/virtual-library-mcp/auth.py
+++ b/virtual-library-mcp/auth.py
@@ -31,10 +31,43 @@ from fastmcp.server.auth import AuthProvider
 from fastmcp.server.auth.providers.google import GoogleProvider
 from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware, MiddlewareContext
+from key_value.aio.protocols import AsyncKeyValue
+from key_value.aio.stores.firestore import (
+    FirestoreStore,
+    FirestoreV1CollectionSanitizationStrategy,
+    FirestoreV1KeySanitizationStrategy,
+)
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 
 from config import ServerConfig
 
 logger = logging.getLogger(__name__)
+
+
+def build_oauth_client_storage(config: ServerConfig) -> AsyncKeyValue | None:
+    """Build shared encrypted OAuth storage for horizontally hosted servers.
+
+    FastMCP's Linux default is process memory, which loses DCR registrations
+    whenever Cloud Run scales to zero or starts another instance. Firestore is
+    only selected when all three production settings are present; local OAuth
+    development keeps FastMCP's normal storage behavior.
+    """
+    if not config.legacy_oauth_firestore_project:
+        return None
+
+    assert config.legacy_oauth_storage_encryption_key is not None
+    firestore = FirestoreStore(
+        project=config.legacy_oauth_firestore_project,
+        database="(default)",
+        default_collection="virtual-library-oauth",
+        key_sanitization_strategy=FirestoreV1KeySanitizationStrategy(),
+        collection_sanitization_strategy=FirestoreV1CollectionSanitizationStrategy(),
+    )
+    return FernetEncryptionWrapper(
+        key_value=firestore,
+        source_material=config.legacy_oauth_storage_encryption_key,
+        salt=f"{config.server_name}:legacy-oauth-storage:v1",
+    )
 
 
 class EmailAllowlistMiddleware(Middleware):
@@ -75,6 +108,12 @@ def build_auth_provider(config: ServerConfig) -> AuthProvider | None:
     assert config.google_client_secret is not None
 
     logger.info("OAuth 2.1 enabled: Google identity, base_url=%s", config.base_url)
+    client_storage = build_oauth_client_storage(config)
+    if client_storage is not None:
+        logger.info(
+            "Legacy OAuth registrations use encrypted Firestore storage (project=%s)",
+            config.legacy_oauth_firestore_project,
+        )
     return GoogleProvider(
         client_id=config.google_client_id,
         client_secret=config.google_client_secret,
@@ -83,4 +122,6 @@ def build_auth_provider(config: ServerConfig) -> AuthProvider | None:
         # Defaults kept explicit for the reader:
         require_authorization_consent=True,  # user sees a consent page
         enable_cimd=True,  # SEP-991 client registration via metadata documents
+        client_storage=client_storage,
+        jwt_signing_key=config.legacy_oauth_jwt_signing_key,
     )

--- a/virtual-library-mcp/config.py
+++ b/virtual-library-mcp/config.py
@@ -159,6 +159,34 @@ class ServerConfig(BaseSettings):
         ),
     )
 
+    legacy_oauth_firestore_project: str | None = Field(
+        default=None,
+        description=(
+            "Google Cloud project containing the Firestore database used for "
+            "durable legacy OAuth client registrations and upstream tokens. "
+            "Unset keeps FastMCP's local-development storage default."
+        ),
+    )
+
+    legacy_oauth_jwt_signing_key: str | None = Field(
+        default=None,
+        description=(
+            "Stable secret used to sign FastMCP OAuth proxy tokens. Required "
+            "with legacy_oauth_firestore_project so tokens remain valid across "
+            "Cloud Run instances and revisions."
+        ),
+        repr=False,
+    )
+
+    legacy_oauth_storage_encryption_key: str | None = Field(
+        default=None,
+        description=(
+            "Secret source material used to encrypt legacy OAuth registrations "
+            "and upstream tokens before storing them in Firestore."
+        ),
+        repr=False,
+    )
+
     allow_insecure_http: bool = Field(
         default=False,
         description=(
@@ -406,6 +434,19 @@ class ServerConfig(BaseSettings):
                 raise ValueError(
                     f"auth_enabled=true but missing required settings: {', '.join(missing)}"
                 )
+        oauth_storage_settings = {
+            "VIRTUAL_LIBRARY_LEGACY_OAUTH_FIRESTORE_PROJECT": self.legacy_oauth_firestore_project,
+            "VIRTUAL_LIBRARY_LEGACY_OAUTH_JWT_SIGNING_KEY": self.legacy_oauth_jwt_signing_key,
+            "VIRTUAL_LIBRARY_LEGACY_OAUTH_STORAGE_ENCRYPTION_KEY": (
+                self.legacy_oauth_storage_encryption_key
+            ),
+        }
+        if any(oauth_storage_settings.values()) and not all(oauth_storage_settings.values()):
+            missing = [name for name, value in oauth_storage_settings.items() if not value]
+            raise ValueError(
+                "legacy OAuth persistent storage requires all settings; missing: "
+                + ", ".join(missing)
+            )
         if self.discovery_era == "legacy" and not self.auth_enabled:
             # Ceding the shared well-knowns to the legacy era only makes
             # sense when a legacy OAuth stack exists to serve them; without

--- a/virtual-library-mcp/docs/DEPLOYMENT.md
+++ b/virtual-library-mcp/docs/DEPLOYMENT.md
@@ -109,7 +109,9 @@ just bootstrap <PROJECT_ID>
 This applies `terraform/bootstrap/`: the Terraform state bucket, the
 Workload Identity Federation pool/provider (trusting only
 `willtech3/mcp-learning` on `refs/heads/main`), and the deployer service
-account (including permission to create/manage the Firestore OAuth database).
+account (including the six-permission `roles/datastore.cloneAdmin` role needed
+to create and inspect the Firestore OAuth database, without access to its
+documents).
 It prints four outputs used in the next steps, including the
 service's **deterministic URL** (`base_url`) — knowable before anything
 is deployed, which is what lets the OAuth client be registered up front.
@@ -119,8 +121,12 @@ needed to change or destroy these few resources.
 
 > **Existing deployment upgrading to persistent OAuth storage:** run this
 > bootstrap command once from the updated branch before merging it. That adds
-> the deployer's Firestore role; the normal post-merge workflow creates the
-> database and performs every remaining deployment step.
+> the deployer's narrow Firestore database-creation role; the normal post-merge
+> workflow creates the database and performs every remaining deployment step.
+> If the gitignored local bootstrap state was not retained, do not approve a
+> plan that proposes recreating the existing bootstrap resources. Recover or
+> import that state, or grant only `roles/datastore.cloneAdmin` to the existing
+> deployer service account before running the normal deployment.
 
 ### Step 2 — Create the Google OAuth client (console, once)
 

--- a/virtual-library-mcp/docs/DEPLOYMENT.md
+++ b/virtual-library-mcp/docs/DEPLOYMENT.md
@@ -38,6 +38,7 @@ MCP-specific properties are handled explicitly:
 MCP client ──OAuth 2.1 + PKCE──> Cloud Run (virtual-library-mcp)
    │                                 │ LEGACY era: Google OAuth + email allowlist
    │<──discovery, tokens─────────────│ MODERN era: bearer JWTs from bundled demo AS
+   │                                 │ encrypted OAuth state ──> Firestore
    │                                 │ SQLite catalog (baked into image)
    └──sign-in──> Google OAuth <──────┘ secrets from Secret Manager
 ```
@@ -79,6 +80,12 @@ protocol eras have authentication enabled.
   runs sessionless; the session-stream features (sampling, elicitation,
   subscriptions) are local-development demos, and the modern era is
   stateless by design.
+- **Durable legacy OAuth state:** FastMCP defaults to process memory on Linux.
+  That is not sufficient on Cloud Run: ChatGPT may dynamically register on
+  one instance, then open `/authorize` after scale-to-zero or on another
+  instance. The deployment therefore stores DCR registrations and upstream
+  tokens in Firestore, encrypted by the application, and uses a stable JWT
+  signing key from Secret Manager.
 
 ## One-time setup
 
@@ -102,12 +109,18 @@ just bootstrap <PROJECT_ID>
 This applies `terraform/bootstrap/`: the Terraform state bucket, the
 Workload Identity Federation pool/provider (trusting only
 `willtech3/mcp-learning` on `refs/heads/main`), and the deployer service
-account. It prints four outputs used in the next steps, including the
+account (including permission to create/manage the Firestore OAuth database).
+It prints four outputs used in the next steps, including the
 service's **deterministic URL** (`base_url`) — knowable before anything
 is deployed, which is what lets the OAuth client be registered up front.
 
 The bootstrap state file stays local (gitignored); keep it — it's only
 needed to change or destroy these few resources.
+
+> **Existing deployment upgrading to persistent OAuth storage:** run this
+> bootstrap command once from the updated branch before merging it. That adds
+> the deployer's Firestore role; the normal post-merge workflow creates the
+> database and performs every remaining deployment step.
 
 ### Step 2 — Create the Google OAuth client (console, once)
 
@@ -149,15 +162,16 @@ just secret-set     # prompts for the secret from Step 2; pipes it to gcloud
 
 Secrets never touch Terraform state, the repo, or GitHub — Terraform
 manages the containers, values go straight to Secret Manager. The MRTR
-HMAC key is seeded automatically by the workflow (random bytes, first run
-only).
+HMAC key plus separate legacy OAuth signing and storage-encryption keys are
+seeded automatically by the workflow (random bytes, first run only).
 
 ## Deploying (every time)
 
 Push to `main` touching `virtual-library-mcp/**`, or run the **Deploy**
 workflow manually. The pipeline: quality gates (ruff, pyright, pytest) →
 WIF auth → build + push image tagged with the git SHA → `terraform apply`
-→ smoke tests (health, a 401 from *each* era, discovery documents).
+→ smoke tests (health, a 401 from *each* era, legacy and modern discovery
+documents).
 
 Rollback: revert the commit on `main` and let the workflow redeploy —
 images are tagged by SHA and stay in the registry. (Deploying non-`main`
@@ -174,6 +188,9 @@ curl "$BASE_URL/health"
 # Modern era discovery chain (what a 2026-07-28 client walks):
 curl "$BASE_URL/.well-known/oauth-protected-resource/mcp"
 curl "$BASE_URL/.well-known/oauth-authorization-server/auth"
+
+# Legacy authorization server metadata (what ChatGPT walks):
+curl "$BASE_URL/.well-known/oauth-authorization-server"
 ```
 
 Then connect a real client — the `mcp-client-learning` sibling repo
@@ -211,7 +228,8 @@ this moves fast):
 - [x] Email allowlist on the legacy era (authorization, not just authentication)
 - [x] Keyless CI (Workload Identity Federation pinned to repo + branch); no SA keys exist
 - [x] Secrets only in Secret Manager; never in Terraform state, git, or GitHub
-- [x] Least-privilege runtime SA (logs + metrics + two secrets); deployer SA scoped to its job
+- [x] Legacy OAuth registrations/tokens encrypted in Firestore; stable signing key across instances
+- [x] Least-privilege runtime SA (logs + metrics + four secrets + Firestore data); deployer SA scoped to its job
 - [x] Immutable image tags (git SHA); rate limiting; non-root container
 - [ ] Known, documented gap: the modern era's demo AS issues tokens without identity — demo data only
 
@@ -221,8 +239,10 @@ this moves fast):
   into the image; checkouts vanish when an instance recycles. Intentional
   for a self-resetting demo. For durable state: Cloud SQL (Postgres) +
   the SQLAlchemy URL in config.
-- **Costs.** Scale-to-zero + `cpu_idle` keeps an idle demo at ~$0/month;
-  Secret Manager, Artifact Registry, and the state bucket are pennies.
+- **Costs.** Scale-to-zero + `cpu_idle` keeps an idle demo inexpensive;
+  Firestore's small OAuth workload, Secret Manager, Artifact Registry, and
+  the state bucket should remain in their low/free usage tiers for a personal
+  demo, but check current GCP pricing for your region.
 - **Logs.** `gcloud run services logs read virtual-library-mcp --region=<region>`;
   Logfire tracing activates automatically when `LOGFIRE_TOKEN` is set.
 - **Terraform state** lives in `gs://<PROJECT_ID>-tfstate` (versioned).

--- a/virtual-library-mcp/justfile
+++ b/virtual-library-mcp/justfile
@@ -297,6 +297,15 @@ tf-init:
 tf-plan:
     terraform -chdir=terraform plan
 
+tf-format:
+    terraform fmt -recursive terraform
+
+tf-format-check:
+    terraform fmt -check -recursive terraform
+
+tf-validate:
+    terraform -chdir=terraform validate
+
 # === PRODUCTION ===
 
 # Build distribution package

--- a/virtual-library-mcp/pyproject.toml
+++ b/virtual-library-mcp/pyproject.toml
@@ -24,6 +24,9 @@ classifiers = [
 dependencies = [
     # MCP framework (v3, targets protocol revision 2025-11-25)
     "fastmcp[apps,tasks]>=3.4,<4",
+    # Cloud Run recycles instances, so FastMCP's OAuth proxy needs a shared
+    # registration/token store instead of its Linux in-memory default.
+    "py-key-value-aio[firestore]>=0.4.5",
     # FastMCP intentionally leaves Prefab's upper bound open; pin it for
     # reproducible MCP App rendering while the UI package evolves quickly.
     "prefab-ui==0.20.2",

--- a/virtual-library-mcp/terraform/apis.tf
+++ b/virtual-library-mcp/terraform/apis.tf
@@ -4,6 +4,7 @@ resource "google_project_service" "apis" {
   for_each = toset([
     "run.googleapis.com",
     "artifactregistry.googleapis.com",
+    "firestore.googleapis.com",
     "secretmanager.googleapis.com",
     "iam.googleapis.com",
   ])

--- a/virtual-library-mcp/terraform/bootstrap/main.tf
+++ b/virtual-library-mcp/terraform/bootstrap/main.tf
@@ -161,7 +161,7 @@ resource "google_project_iam_member" "deployer_roles" {
   for_each = toset([
     "roles/run.admin",                       # Cloud Run service + invoker IAM
     "roles/artifactregistry.admin",          # image repo + docker push
-    "roles/datastore.owner",                 # creates/manages the Firestore OAuth store
+    "roles/datastore.cloneAdmin",            # creates/reads database metadata; no entity access
     "roles/secretmanager.admin",             # secret containers + versions + IAM
     "roles/iam.serviceAccountAdmin",         # creates the runtime SA
     "roles/iam.serviceAccountUser",          # actAs the runtime SA on deploy

--- a/virtual-library-mcp/terraform/bootstrap/main.tf
+++ b/virtual-library-mcp/terraform/bootstrap/main.tf
@@ -161,6 +161,7 @@ resource "google_project_iam_member" "deployer_roles" {
   for_each = toset([
     "roles/run.admin",                       # Cloud Run service + invoker IAM
     "roles/artifactregistry.admin",          # image repo + docker push
+    "roles/datastore.owner",                 # creates/manages the Firestore OAuth store
     "roles/secretmanager.admin",             # secret containers + versions + IAM
     "roles/iam.serviceAccountAdmin",         # creates the runtime SA
     "roles/iam.serviceAccountUser",          # actAs the runtime SA on deploy

--- a/virtual-library-mcp/terraform/cloudrun.tf
+++ b/virtual-library-mcp/terraform/cloudrun.tf
@@ -79,10 +79,32 @@ resource "google_cloud_run_v2_service" "server" {
         value = jsonencode(var.auth_allowed_emails)
       }
       env {
+        name  = "VIRTUAL_LIBRARY_LEGACY_OAUTH_FIRESTORE_PROJECT"
+        value = var.project_id
+      }
+      env {
         name = "VIRTUAL_LIBRARY_GOOGLE_CLIENT_SECRET"
         value_source {
           secret_key_ref {
             secret  = google_secret_manager_secret.oauth_client_secret.secret_id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "VIRTUAL_LIBRARY_LEGACY_OAUTH_JWT_SIGNING_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.oauth_jwt_signing_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "VIRTUAL_LIBRARY_LEGACY_OAUTH_STORAGE_ENCRYPTION_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.oauth_storage_encryption_key.secret_id
             version = "latest"
           }
         }
@@ -149,6 +171,9 @@ resource "google_cloud_run_v2_service" "server" {
     google_project_service.apis,
     google_secret_manager_secret_iam_member.service_can_read,
     google_secret_manager_secret_iam_member.request_state_read,
+    google_secret_manager_secret_iam_member.oauth_jwt_signing_key_read,
+    google_secret_manager_secret_iam_member.oauth_storage_encryption_key_read,
+    google_project_iam_member.oauth_firestore_user,
   ]
 }
 

--- a/virtual-library-mcp/terraform/firestore.tf
+++ b/virtual-library-mcp/terraform/firestore.tf
@@ -1,0 +1,27 @@
+# Durable FastMCP OAuth proxy storage.
+#
+# ChatGPT dynamically registers before opening the user's browser. Cloud Run
+# may scale to zero between those requests or route them to different
+# instances, so FastMCP's Linux in-memory default cannot be used in production.
+# The application encrypts every value before it reaches this database.
+
+resource "google_firestore_database" "oauth" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+
+  # Removing this resource must not silently erase registered OAuth clients
+  # or upstream refresh tokens.
+  deletion_policy = "ABANDON"
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_project_iam_member" "oauth_firestore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.run_service.email}"
+
+  depends_on = [google_firestore_database.oauth]
+}

--- a/virtual-library-mcp/terraform/secrets.tf
+++ b/virtual-library-mcp/terraform/secrets.tf
@@ -43,3 +43,39 @@ resource "google_secret_manager_secret_iam_member" "request_state_read" {
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.run_service.email}"
 }
+
+# Stable FastMCP OAuth proxy keys. The deploy workflow seeds both values once;
+# Terraform manages only their containers and IAM policies. Keeping signing
+# and at-rest encryption keys separate avoids key reuse across cryptographic
+# purposes.
+resource "google_secret_manager_secret" "oauth_jwt_signing_key" {
+  secret_id = "${var.service_name}-oauth-jwt-signing-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_iam_member" "oauth_jwt_signing_key_read" {
+  secret_id = google_secret_manager_secret.oauth_jwt_signing_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_service.email}"
+}
+
+resource "google_secret_manager_secret" "oauth_storage_encryption_key" {
+  secret_id = "${var.service_name}-oauth-storage-encryption-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret_iam_member" "oauth_storage_encryption_key_read" {
+  secret_id = google_secret_manager_secret.oauth_storage_encryption_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.run_service.email}"
+}

--- a/virtual-library-mcp/tests/test_auth.py
+++ b/virtual-library-mcp/tests/test_auth.py
@@ -10,9 +10,10 @@ import httpx
 import pytest
 from fastmcp import FastMCP
 from fastmcp.server.auth.providers.google import GoogleProvider
+from key_value.aio.stores.memory import MemoryStore
 from pydantic import ValidationError
 
-from auth import build_auth_provider
+from auth import build_auth_provider, build_oauth_client_storage
 from config import ServerConfig
 
 FAKE_AUTH = {
@@ -74,6 +75,98 @@ class TestProviderConstruction:
     def test_provider_uses_configured_base_url(self, clean_env):
         provider = build_auth_provider(_config(**FAKE_AUTH))
         assert str(provider.base_url).rstrip("/") == "https://library.example.app"
+
+    def test_firestore_storage_is_encrypted_and_sanitized(self, clean_env, monkeypatch):
+        calls = {}
+
+        class StubFirestoreStore:
+            def __init__(self, **kwargs):
+                calls["firestore"] = kwargs
+
+        class StubEncryptedStore:
+            def __init__(self, **kwargs):
+                calls["encryption"] = kwargs
+
+        monkeypatch.setattr("auth.FirestoreStore", StubFirestoreStore)
+        monkeypatch.setattr("auth.FernetEncryptionWrapper", StubEncryptedStore)
+
+        config = _config(
+            **FAKE_AUTH,
+            legacy_oauth_firestore_project="library-project",
+            legacy_oauth_jwt_signing_key="jwt-key",
+            legacy_oauth_storage_encryption_key="storage-key",
+        )
+        storage = build_oauth_client_storage(config)
+
+        assert isinstance(storage, StubEncryptedStore)
+        assert calls["firestore"]["project"] == "library-project"
+        assert calls["firestore"]["database"] == "(default)"
+        assert calls["firestore"]["default_collection"] == "virtual-library-oauth"
+        assert calls["firestore"]["key_sanitization_strategy"] is not None
+        assert calls["firestore"]["collection_sanitization_strategy"] is not None
+        assert calls["encryption"]["source_material"] == "storage-key"
+
+    async def test_shared_storage_survives_provider_instance_change(self, clean_env):
+        """A client registered on one instance must authorize on another."""
+        shared_storage = MemoryStore()
+        provider_kwargs = {
+            "client_id": "google-client-id",
+            "client_secret": "google-client-secret",
+            "base_url": "https://library.example.app",
+            "required_scopes": [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email",
+            ],
+            "client_storage": shared_storage,
+            "jwt_signing_key": "stable-test-signing-key",
+        }
+        registration_app = FastMCP(
+            "registration-instance", auth=GoogleProvider(**provider_kwargs)
+        ).http_app()
+        authorization_app = FastMCP(
+            "authorization-instance", auth=GoogleProvider(**provider_kwargs)
+        ).http_app()
+        redirect_uri = "https://chatgpt.com/connector/oauth/test"
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=registration_app),
+            base_url="https://library.example.app",
+        ) as registration_client:
+            registered = await registration_client.post(
+                "/register",
+                json={
+                    "client_name": "ChatGPT",
+                    "redirect_uris": [redirect_uri],
+                    "grant_types": ["authorization_code", "refresh_token"],
+                    "response_types": ["code"],
+                    "token_endpoint_auth_method": "client_secret_post",
+                    "scope": "openid https://www.googleapis.com/auth/userinfo.email",
+                },
+            )
+
+        assert registered.status_code == 201, registered.text
+        client_id = registered.json()["client_id"]
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=authorization_app),
+            base_url="https://library.example.app",
+        ) as authorization_client:
+            authorized = await authorization_client.get(
+                "/authorize",
+                params={
+                    "response_type": "code",
+                    "client_id": client_id,
+                    "redirect_uri": redirect_uri,
+                    "scope": "openid https://www.googleapis.com/auth/userinfo.email",
+                    "code_challenge": "x" * 43,
+                    "code_challenge_method": "S256",
+                    "resource": "https://library.example.app/mcp",
+                },
+            )
+
+        assert authorized.status_code == 302
+        assert authorized.headers["location"].startswith("https://library.example.app/consent?")
+        assert "Client Not Registered" not in authorized.text
 
 
 class TestOAuthDiscoveryEndpoints:

--- a/virtual-library-mcp/tests/test_config.py
+++ b/virtual-library-mcp/tests/test_config.py
@@ -206,6 +206,30 @@ class TestServerConfig:
         # But the value should still be accessible
         assert config.external_api_key == "secret-key"
 
+    def test_oauth_storage_keys_are_hidden_in_repr(self):
+        config = ServerConfig(
+            legacy_oauth_firestore_project="library-project",
+            legacy_oauth_jwt_signing_key="jwt-signing-secret",
+            legacy_oauth_storage_encryption_key="storage-encryption-secret",
+        )
+
+        config_str = repr(config)
+        assert "jwt-signing-secret" not in config_str
+        assert "storage-encryption-secret" not in config_str
+
+    def test_oauth_persistent_storage_requires_complete_configuration(self):
+        with pytest.raises(ValidationError, match="persistent storage requires all settings"):
+            ServerConfig(legacy_oauth_firestore_project="library-project")
+
+    def test_oauth_persistent_storage_accepts_complete_configuration(self):
+        config = ServerConfig(
+            legacy_oauth_firestore_project="library-project",
+            legacy_oauth_jwt_signing_key="jwt-key",
+            legacy_oauth_storage_encryption_key="storage-key",
+        )
+
+        assert config.legacy_oauth_firestore_project == "library-project"
+
     def test_global_config_singleton(self):
         """Test global configuration singleton pattern."""
         # Reset to ensure clean state

--- a/virtual-library-mcp/uv.lock
+++ b/virtual-library-mcp/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "aiofile"
@@ -593,6 +598,71 @@ tasks = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/66/b4ba60005743e01933e22b4f62313e063f7460458b7d8a358427b4930013/google_auth-2.56.0.tar.gz", hash = "sha256:f90fa030b569a92654b9d690665a073841df33d57487be53db583a9a0867a553", size = 364629, upload-time = "2026-07-13T19:09:57.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/7d/cd3e187f14ce832e419e70709bfcc40cb0dc11517d5d03c9d3919bcc3101/google_auth-2.56.0-py3-none-any.whl", hash = "sha256:6e88c10217e07a92bfd01cac8ee99e32ccfb08414c3102e6c5b8d58f37a0d1e0", size = 257976, upload-time = "2026-07-13T19:09:42.685Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-firestore"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e2/7db007e30a84a2134a8c2880d3cfc30673f5f37f4e3b5b50ead6c3c61465/google_cloud_firestore-2.28.0.tar.gz", hash = "sha256:8211418bd746f3857046fc375138ddd0dfb023d5012545a9ade149be1461c6db", size = 651021, upload-time = "2026-06-25T23:39:43.754Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/96/6d58d540145b06d372a9ead34cf50ff17f35296cf9a8c43ccc141aa207ea/google_cloud_firestore-2.28.0-py3-none-any.whl", hash = "sha256:055daab3e5fb292f389b4e7d9e03dffb30f38a3463c23363f93d25569c933e59", size = 431943, upload-time = "2026-06-25T23:39:11.735Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -613,7 +683,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -621,7 +693,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -629,7 +703,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -637,14 +713,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -652,7 +732,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -666,6 +748,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.82.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/88/d1350bf3343a2ed87d801584e40609f6c6bd3087926eeca03de50348cf4a/grpcio-1.82.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:c09bd5fa0d5b1fbd773ec349fe61441c3e4ebf168c229aa7538a820bdfad6a58", size = 6144689, upload-time = "2026-07-08T12:34:55.567Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/33/71875cdecd27c24ac1385d4783a09853f01b84a825a36aec2a2bc7d0d080/grpcio-1.82.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1eae24810720734598e3e6a1a528d5de0f265fe3fc86575e9ecce424b9ec7379", size = 11952034, upload-time = "2026-07-08T12:34:58.128Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/d9125df3d8a140dec12cc82c05b7deafedeababcff6496f28b2fd5634d10/grpcio-1.82.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a6bd5daf5bde7b24d7ad2cbaf8bf9eac620d96222016bb5e7ddde930dec0673f", size = 6710772, upload-time = "2026-07-08T12:35:01.33Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9b/69e2d1627398b964f34437dc476a5aff5a2cc8e7f247d26272b5674b5faf/grpcio-1.82.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1ecfde669cb687ac020d31ff76debe5dc7a62213335f02262eb6625628da1c03", size = 7450677, upload-time = "2026-07-08T12:35:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e7/8f855ca29c294956122a2a73023655b9b02602d5111dad2b9b00e7631c68/grpcio-1.82.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:011c8badee95734dee8bf05ce3464756a0ac3ebb8d443afd20c0e2b5e4640ad9", size = 6886855, upload-time = "2026-07-08T12:35:06.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f0/fa87e85f49925f44c479d07e58b051e69bcfef6b6d5fbc6749d140f6730a/grpcio-1.82.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b85f4564926fb23114d239392bdcae200db1e6179629edd7d7ab0ab89c96a197", size = 7501323, upload-time = "2026-07-08T12:35:08.49Z" },
+    { url = "https://files.pythonhosted.org/packages/67/55/2e0b10ae1d3ef9dcc480b91dc2158f4931fc4675d3af0a2836e39b2a744f/grpcio-1.82.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2c0c8270833395644c3fe6b6a806397955a2bc0538000a19a78b90c05a6c16e0", size = 8536899, upload-time = "2026-07-08T12:35:10.975Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/a3d8b0431fa221efc51ee39d73595ede74ba82a43b7c4313192e580face2/grpcio-1.82.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2ba199205ff46c7778290fe1673c91ac8e7e45678dd5c86e9e56fa33ec8788f6", size = 7913892, upload-time = "2026-07-08T12:35:13.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/92/f2651ec704d9852a56faef394775038afba435b50ce82ab2404d119c3355/grpcio-1.82.1-cp312-cp312-win32.whl", hash = "sha256:06127691866e295c14e84a1fb86356dd962254f6abd0da4ca4b001eea9e89438", size = 4240985, upload-time = "2026-07-08T12:35:16.048Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4f/a5fe8bf0d0a1b24855f370293075c931f27de4eb55f0f158786095bf3c11/grpcio-1.82.1-cp312-cp312-win_amd64.whl", hash = "sha256:1fa3223a3a2e1db74f4c2b255189eb7ea875dfba56e221d252ee3fc7b204778e", size = 5001580, upload-time = "2026-07-08T12:35:18.689Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3e/496992d08c0aaa11272eb6228dc8ab947da01fe835de243cd00521bce4c4/grpcio-1.82.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b454a2d97bfab7565683a02345f86bd182ab69fd7c2bdb7414171e7538f266b1", size = 6146068, upload-time = "2026-07-08T12:35:21.365Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8f/f263d6f14fdba6b56cfadd91fd3e158a52682b72c6016d1f8723d435659f/grpcio-1.82.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:3dde70abfc80b3be11de53ba0d601c439e7fb2afd3583ad1788d1146bec92fdc", size = 11948600, upload-time = "2026-07-08T12:35:24.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/14/3a02e6ee49c2d85bc15eaae321e0e11ab3542cad3c5b2de121ecce0c4296/grpcio-1.82.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5523099c98c292ea1ae08e617249db760c56a78f8deae879027fe7d1ffbcbf6", size = 6714591, upload-time = "2026-07-08T12:35:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/69/80/58e3738696f48ab7645347b98d8a7f93d10e00e6218388fbfcd6c9310e3d/grpcio-1.82.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5e5c4dc0a59b0f8490a6bdfd6fc8395b9d8ad8a8407c7d67ca7b5bba15c0877f", size = 7454995, upload-time = "2026-07-08T12:35:29.599Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6c/2557c1a889363072fbf2285ecd0e8c44860d4dbd60f017a32537c5b863e2/grpcio-1.82.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c40d94ba820329cc191981bc22fa6f6eed0799c6d921f3c6709521d59d4a2fd7", size = 6888621, upload-time = "2026-07-08T12:35:32.38Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/66/907706ccaff1223f1e10fd5b37fc16faead43392fccb4e786e7e390ac141/grpcio-1.82.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c816180e31e273caaec6f8bd86a8392499d5bbb26f41da44e3dce48bde69095", size = 7505069, upload-time = "2026-07-08T12:35:35.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/ff97b0d0f635987ee5ec80dfedafa1aad629303745d48e8637d10eec5b80/grpcio-1.82.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e31fd780b261830720cb70b0fd8f0aa51d49e75a66d7464ad2e31d4b765f2580", size = 8535384, upload-time = "2026-07-08T12:35:37.954Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9e/a97fddd970a8d1588cade06eca20443761c1858b0ad6590a5c835aa18062/grpcio-1.82.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d76152d7c31d7210d4a106e5d8b64da5bba5d6abf11be30e2f7b0a0c59bbcbf", size = 7910707, upload-time = "2026-07-08T12:35:40.797Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e4/eaba1517888af483a88d449eb7566f0f7f63446d46f339c5891798435875/grpcio-1.82.1-cp313-cp313-win32.whl", hash = "sha256:38e9dcb5258226fb3282630b31b16a968df52c8c6ad514af540646e0a4578f8a", size = 4240363, upload-time = "2026-07-08T12:35:43.298Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/66a98d47732e35290bef722f6149fed3709cd4cf61166f6f53a12f417302/grpcio-1.82.1-cp313-cp313-win_amd64.whl", hash = "sha256:3dbfb52c36d9511ac2b8e6c94fdde837b393ae520cc321f52a333a2deedf5a90", size = 5000980, upload-time = "2026-07-08T12:35:46.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/cb/cf9ae9e164c6e6dc8a494faa9771763df9da150eefe19671009624d1559f/grpcio-1.82.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:35f990f7784c8fd2872644f07f96ebb4d9e48e145a190ab80d0280af91a1bfb2", size = 6146901, upload-time = "2026-07-08T12:35:49.261Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/eccf26dbcfb7f7cab8027c5490a16c8937c5aa7a2ec20a3eab2cf7a43165/grpcio-1.82.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:46536a4a1f4434df3c851b9254ff6fc7df5705b273681a15ca277d5921c178a0", size = 11954756, upload-time = "2026-07-08T12:35:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/75/3b3b4a3cc9f084b026af96e1d3e539b1af29ec7f41ed0dfff3cb99cc8626/grpcio-1.82.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d6650a7c1ebb7921c70e12a385439a8118efb99e669fa9ed31cf25db1843937c", size = 6723087, upload-time = "2026-07-08T12:35:54.973Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/b0f0c9b1400a99a4da4c09b114f101b192f8f11192e76f620b8962f5d90b/grpcio-1.82.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b8e110c66df5204c0506d6c8787b35d48b8b699ef5aa366d6c4d67325c67fe9a", size = 7454542, upload-time = "2026-07-08T12:35:57.586Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bd/428e38868382aa193697a5aa53973f29c58e58ba4268aa0c86a2715ee58b/grpcio-1.82.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f853eae07235a51a27bb5d6a9a175a59ca55dc9b99edc6ce2f76f07332d333ae", size = 6889588, upload-time = "2026-07-08T12:36:00.012Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ce/03e01d5e10259bf5c08ee50570cc94724e79c956f61fd2f09b341af0956c/grpcio-1.82.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:60b0f2c95337694fc094b77d9f60f50566c84b5677393e342eb98daeee242d98", size = 7514166, upload-time = "2026-07-08T12:36:02.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/59/278b4b600329e2ba3849f3c1ea3c820b3a01b38a7ad184ba09595e8d2733/grpcio-1.82.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b064fc444812bdaa9825d33c26f8d732d63ee6a5d78557c1faf92c98687fed27", size = 8536166, upload-time = "2026-07-08T12:36:05.349Z" },
+    { url = "https://files.pythonhosted.org/packages/44/27/7ccf2ef00f27a8e47a79d641c8ceaf7d3028c7a03d9a97b4c8a9a783c086/grpcio-1.82.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d7ede11d747b4e1bd05e3bc0260e155b65a88735a895a10f6521f19b889511e", size = 7912572, upload-time = "2026-07-08T12:36:08.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/be/33742482d2753f2d3a1b7641664b6622262d44f2f3b609f13425dd86d36f/grpcio-1.82.1-cp314-cp314-win32.whl", hash = "sha256:3d21f19838dc255ecbb79321b15ae9b98fbddff4c3d4aedb0a81bdd7f4ab572a", size = 4321856, upload-time = "2026-07-08T12:36:10.899Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/67/03329c847172c78ddeb1eb9be6b444fdbc12775a84c958b27e427e7b926d/grpcio-1.82.1-cp314-cp314-win_amd64.whl", hash = "sha256:e20f1edbb15f99e3128ec86433f9785fd5a451d8f115e74fe0056134f092a9d5", size = 5141114, upload-time = "2026-07-08T12:36:13.595Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/26/0aa9168c87882381fd810d140c279a2490ed6aee655f0515d6f56c5ca404/grpcio_status-1.81.1.tar.gz", hash = "sha256:9389a03e746017b10f0630c064289201458f3ce01f5d7ef4b0bebc1ef6cf82ad", size = 13923, upload-time = "2026-06-11T12:58:48.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/5e/5abfec5f7e89d3b7993d57cfb025ca5f968a2c18656d7fcda2b6919440b9/grpcio_status-1.81.1-py3-none-any.whl", hash = "sha256:08072fa9995f4a95c647fc6f4f85e2411573d00087bcabdf30f260114338f232", size = 14638, upload-time = "2026-06-11T12:58:31.982Z" },
 ]
 
 [[package]]
@@ -1104,6 +1241,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1136,6 +1285,10 @@ filetree = [
     { name = "aiofile" },
     { name = "anyio" },
 ]
+firestore = [
+    { name = "google-auth" },
+    { name = "google-cloud-firestore" },
+]
 keyring = [
     { name = "keyring" },
 ]
@@ -1144,6 +1297,27 @@ memory = [
 ]
 redis = [
     { name = "redis" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1852,6 +2026,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "logfire" },
     { name = "prefab-ui" },
+    { name = "py-key-value-aio", extra = ["firestore"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -1878,6 +2053,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.21" },
     { name = "logfire", specifier = ">=4" },
     { name = "prefab-ui", specifier = "==0.20.2" },
+    { name = "py-key-value-aio", extras = ["firestore"], specifier = ">=0.4.5" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pydantic-settings", specifier = ">=2.10" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },


### PR DESCRIPTION
## Summary

- persist FastMCP's legacy OAuth dynamic-client registrations and upstream tokens in encrypted Firestore storage
- use a stable JWT signing key and a separate storage-encryption key from Secret Manager
- provision Firestore, least-privilege runtime access, and a safe existing-deployment migration order in GitHub Actions
- add a regression test that registers through one provider instance and authorizes through another

## Root cause

Cloud Run logs show ChatGPT receiving a successful `201` from `POST /register`, followed by `400 Client Not Registered` from `/authorize` on a different/recycled instance. FastMCP's Linux default OAuth client store is process memory, so scale-to-zero and horizontal routing discarded the registration between those requests.

## Least-privilege deployment

The existing GitHub deployer has been granted only `roles/datastore.cloneAdmin`, a six-permission control-plane role used to create/read database metadata and poll operations. It does **not** grant Firestore document/entity access. The Cloud Run runtime service account separately receives `roles/datastore.user` for the encrypted OAuth records.

No pre-merge bootstrap action remains.

## Validation

- `just lint`
- `just typecheck` — 0 errors
- `just test` — 622 passed
- `just tf-format-check`
- `just tf-validate`
- `just docker-build`
- PR CI — passed
