### PR TITLE
Suppress sensitive OAuth HTTP logs

### DIFF
--- a/virtual-library-mcp/auth.py
+++ b/virtual-library-mcp/auth.py
@@ -19,6 +19,7 @@ Security posture implemented here:
 - Tokens are validated server-side on every request; scopes checked
 - Authorization consent screen enabled (require_authorization_consent)
 - Client ID Metadata Documents enabled (enable_cimd, SEP-991)
+- Dependency request logs suppressed so bearer tokens never appear in URLs
 - HTTPS required for the public base URL (config validator)
 - The HTTP transport refuses to start unauthenticated unless explicitly
   opted out via VIRTUAL_LIBRARY_ALLOW_INSECURE_HTTP (dev only)
@@ -42,6 +43,19 @@ from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
 from config import ServerConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _suppress_sensitive_http_client_logs() -> None:
+    """Keep OAuth bearer tokens out of dependency request logs.
+
+    FastMCP's Google verifier sends the opaque access token to Google's
+    tokeninfo endpoint as a query parameter. ``httpx`` logs the complete URL
+    at INFO, while ``httpcore`` may log request details at DEBUG. Keep both
+    dependency loggers at WARNING; application-owned OAuth logs remain
+    available without exposing credentials.
+    """
+    for logger_name in ("httpx", "httpcore"):
+        logging.getLogger(logger_name).setLevel(logging.WARNING)
 
 
 def build_oauth_client_storage(config: ServerConfig) -> AsyncKeyValue | None:
@@ -107,6 +121,7 @@ def build_auth_provider(config: ServerConfig) -> AuthProvider | None:
     assert config.google_client_id is not None
     assert config.google_client_secret is not None
 
+    _suppress_sensitive_http_client_logs()
     logger.info("OAuth 2.1 enabled: Google identity, base_url=%s", config.base_url)
     client_storage = build_oauth_client_storage(config)
     if client_storage is not None:

--- a/virtual-library-mcp/tests/test_auth.py
+++ b/virtual-library-mcp/tests/test_auth.py
@@ -6,6 +6,8 @@ discovery endpoints required by the MCP 2025-11-25 authorization spec
 are actually mounted on the HTTP app.
 """
 
+import logging
+
 import httpx
 import pytest
 from fastmcp import FastMCP
@@ -75,6 +77,27 @@ class TestProviderConstruction:
     def test_provider_uses_configured_base_url(self, clean_env):
         provider = build_auth_provider(_config(**FAKE_AUTH))
         assert str(provider.base_url).rstrip("/") == "https://library.example.app"
+
+    def test_provider_suppresses_sensitive_http_client_logs(self, clean_env, monkeypatch, caplog):
+        """Dependency request logs must not expose bearer tokens in URLs or headers."""
+        httpx_logger = logging.getLogger("httpx")
+        httpcore_logger = logging.getLogger("httpcore")
+        monkeypatch.setattr(httpx_logger, "level", logging.INFO)
+        monkeypatch.setattr(httpcore_logger, "level", logging.DEBUG)
+        fake_token = "fake-google-oauth-token-for-log-test"
+
+        build_auth_provider(_config(**FAKE_AUTH))
+
+        transport = httpx.MockTransport(lambda request: httpx.Response(200, request=request))
+        with caplog.at_level(logging.DEBUG), httpx.Client(transport=transport) as client:
+            client.get(
+                "https://oauth2.googleapis.com/tokeninfo",
+                params={"access_token": fake_token},
+            )
+
+        assert httpx_logger.getEffectiveLevel() >= logging.WARNING
+        assert httpcore_logger.getEffectiveLevel() >= logging.WARNING
+        assert fake_token not in caplog.text
 
     def test_firestore_storage_is_encrypted_and_sanitized(self, clean_env, monkeypatch):
         calls = {}


### PR DESCRIPTION
## What changed

- Raise the `httpx` and `httpcore` dependency loggers to `WARNING` whenever the Google OAuth provider is enabled.
- Add a behavioral regression test that makes a tokeninfo request with a sentinel token and proves it never reaches captured logs.

## Why

FastMCP's Google token verifier sends the access token to Google's tokeninfo endpoint as a query parameter. HTTPX logs the complete request URL at `INFO`, so the process-wide `INFO` logging configuration could copy a bearer token into Cloud Logging.

This keeps application-owned OAuth diagnostics while suppressing dependency request traces that may contain credentials.

## Validation

- `just test` — 623 passed
- `just lint` — passed
- `just format-check` — passed
- `just typecheck` — 0 errors
- Independent security review — no blocking findings