### PR TITLE
Fix hosted MCP App renderer isolation

### DIFF
--- a/virtual-library-mcp/tests/tools/test_apps.py
+++ b/virtual-library-mcp/tests/tools/test_apps.py
@@ -5,7 +5,7 @@ import re
 from types import SimpleNamespace
 
 import pytest
-from fastmcp import Client, FastMCP
+from fastmcp import Client
 
 import apps_server
 import server
@@ -37,6 +37,7 @@ class TestAppDescriptors:
 
     async def test_app_tools_publish_ui_metadata_and_safety_hints(self, client):
         tools = {tool.name: tool for tool in await client.list_tools()}
+        renderer_uris = set()
 
         for name in (
             "browse_catalog_app",
@@ -52,31 +53,31 @@ class TestAppDescriptors:
                 "idempotentHint": True,
                 "openWorldHint": False,
             }
-            assert descriptor["_meta"]["ui"]["resourceUri"].startswith("ui://")
+            renderer_uri = descriptor["_meta"]["ui"]["resourceUri"]
+            assert renderer_uri.startswith("ui://prefab/tool/")
+            renderer_uris.add(renderer_uri)
+
+        assert len(renderer_uris) == 5
 
     async def test_prefab_renderer_resource_is_registered(self, client):
         resources = await client.list_resources()
         renderers = [resource for resource in resources if str(resource.uri).startswith("ui://")]
 
-        assert renderers
-        renderer = (await client.read_resource(renderers[0].uri))[0]
-        assert renderer.mimeType == "text/html;profile=mcp-app"
+        assert len(renderers) == 5
+        for resource in renderers:
+            renderer = (await client.read_resource(resource.uri))[0]
+            assert renderer.mimeType == "text/html;profile=mcp-app"
+            assert "@prefecthq/prefab-ui@0.20.2" in renderer.text
 
-    async def test_renderer_publishes_configured_stable_domain(self, monkeypatch):
+    async def test_modern_renderer_publishes_configured_stable_domain(self, monkeypatch):
         monkeypatch.setattr(
             apps,
             "get_config",
             lambda: SimpleNamespace(base_url="https://library.example"),
         )
-        mcp = FastMCP("domain-test")
-        apps.register(mcp)
+        resource = apps.app_resource_definitions()[0]
 
-        async with Client(mcp) as app_client:
-            resources = await app_client.list_resources()
-            renderer = (await app_client.read_resource(resources[0].uri))[0]
-
-        descriptor = renderer.model_dump(by_alias=True, exclude_none=True)
-        assert descriptor["_meta"]["ui"]["domain"] == "https://library.example"
+        assert resource["meta"]["ui"]["domain"] == "https://library.example"
 
     async def test_modern_registry_exposes_standard_app_extension(self, library):
         registry = ModernRegistry()

--- a/virtual-library-mcp/tools/apps.py
+++ b/virtual-library-mcp/tools/apps.py
@@ -15,7 +15,7 @@ from datetime import date
 from typing import Annotated, Any, Literal
 
 from fastmcp import FastMCP
-from fastmcp.apps import UI_MIME_TYPE, AppConfig, ResourceCSP
+from fastmcp.apps import UI_MIME_TYPE, PrefabAppConfig, ResourceCSP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from prefab_ui.actions import RequestDisplayMode, SendMessage, SetState
@@ -1004,27 +1004,15 @@ def app_resource_definitions() -> list[dict[str, Any]]:
 
 def register(mcp: FastMCP) -> None:
     """Register the UI tools on the FastMCP path used by MCP Apps hosts."""
-    config = get_config()
-    renderer_app = AppConfig(
-        csp=ResourceCSP(**get_renderer_csp()),
-        domain=config.base_url,
-    )
-    tool_app = AppConfig(resourceUri=PREFAB_RENDERER_URI)
-
-    @mcp.resource(
-        PREFAB_RENDERER_URI,
-        name="Virtual Library App Renderer",
-        mime_type=UI_MIME_TYPE,
-        app=renderer_app,
-    )
-    def prefab_renderer() -> str:
-        return get_renderer_html()
-
     for spec in APP_TOOL_SPECS:
         mcp.tool(
             spec.fn,
             name=spec.name,
-            app=tool_app,
+            # FastMCP synthesizes an isolated, per-tool Prefab renderer URI.
+            # ChatGPT binds a component resource to the tool that declared it;
+            # sharing one hand-registered renderer across unrelated app tools
+            # can leave the host with a stale or mismatched component schema.
+            app=PrefabAppConfig(),
             annotations=spec.annotations,
             icons=spec.icons,
             tags=set(spec.tags),


### PR DESCRIPTION
## Summary
- restore FastMCP's supported `PrefabAppConfig` registration for hosted App tools
- give each App tool its own synthesized `ui://prefab/tool/...` renderer resource
- add regression coverage for unique renderer URIs, MIME types, and pinned Prefab assets
- retain the explicit shared renderer only for the independent 2026-07-28 teaching transport

## Why
ChatGPT refreshed and discovered all five hosted App tools, but a call to `checkout_readiness_app` rendered `Unknown component: "undefined"`. The prior catalog App that rendered successfully used FastMCP's per-tool renderer resources. The shared hand-registered renderer let the host bind/cache one component resource across unrelated App tools.

## Validation
- `just prod-check`
- 661 tests passed, 85% coverage
- ruff clean
- pyright 0 errors
- OSV audit clean: 119 packages
- official MCP Inspector 2.1.0 lists five isolated renderer resources
- checkout readiness App renders successfully in the local FastMCP AppBridge

## References
- OpenAI Apps docs: prefer `_meta.ui.resourceUri`; treat the resource URI as a cache key
- MCP Apps extension: Tool + UI Resource
- FastMCP 3.4.2: `PrefabAppConfig` synthesizes per-tool renderer resources