### PR TITLE
Fix modern MCP App renderer serialization

### DIFF
--- a/virtual-library-mcp/modern/registry.py
+++ b/virtual-library-mcp/modern/registry.py
@@ -66,6 +66,7 @@ import jsonschema
 from fastmcp.exceptions import ResourceError, ToolError
 from fastmcp.tools import Tool as FastMCPTool
 from fastmcp.tools import ToolResult as FastMCPToolResult
+from prefab_ui.app import PrefabApp
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from sqlalchemy import select
 
@@ -639,12 +640,16 @@ class ModernRegistry:
             content = [_dump(block) for block in value.content]
             structured = value.structured_content
             is_error = value.is_error
+        elif isinstance(value, PrefabApp):
+            # PrefabApp is a Pydantic model, but its model_dump() is only the
+            # Python construction graph.  The renderer consumes Prefab's wire
+            # protocol, which to_json() builds by recursively serializing every
+            # component and adding the required $prefab version marker.
+            structured = value.to_json()
+            content = [{"type": "text", "text": "[Rendered Prefab UI]"}]
         elif isinstance(value, BaseModel):
             structured = value.model_dump(mode="json", by_alias=True)
-            if "$prefab" in structured:
-                content = [{"type": "text", "text": "[Rendered Prefab UI]"}]
-            else:
-                content = [{"type": "text", "text": json.dumps(structured, indent=2, default=str)}]
+            content = [{"type": "text", "text": json.dumps(structured, indent=2, default=str)}]
         elif isinstance(value, str):
             content = [{"type": "text", "text": value}]
             if entry.wrap_result:

--- a/virtual-library-mcp/tests/modern/test_dispatcher.py
+++ b/virtual-library-mcp/tests/modern/test_dispatcher.py
@@ -60,6 +60,7 @@ _CM_SESSION_PATCHES = [
     "tools.membership.get_session",
     "tools.book_insights.session_scope",
     "tools.patrons.session_scope",
+    "tools.apps.session_scope",
     "resources.books.session_scope",
     "resources.advanced_books.session_scope",
     "resources.patrons.session_scope",
@@ -380,6 +381,26 @@ class TestToolsCall:
         assert result["resultType"] == "complete"
         assert result["structuredContent"]["books"][0]["isbn"] == "9780134685991"
         assert result["content"][0]["type"] == "text"
+
+    async def test_prefab_app_preserves_complete_component_tree(self, dispatcher, library):
+        response = await dispatcher.handle(
+            request(
+                "tools/call",
+                name="checkout_readiness_app",
+                arguments={
+                    "book_query": "Available Book",
+                    "patron_query": "Clean Reader",
+                },
+            ),
+            ENV,
+        )
+
+        structured = response["result"]["structuredContent"]
+        assert "$prefab" in structured, structured
+        assert structured["$prefab"] == {"version": "0.3"}
+        assert structured["view"]["type"] == "Div"
+        assert structured["view"]["children"][0]["type"] == "Column"
+        assert structured["view"]["children"][0]["children"]
 
     async def test_unknown_tool_is_32602(self, dispatcher):
         response = await dispatcher.handle(


### PR DESCRIPTION
## Summary
- serialize Prefab apps with the required Prefab wire protocol on the 2026-07-28 dispatcher
- preserve the complete component tree and protocol version marker
- add a regression test using the checkout-readiness App and an isolated library fixture

## Verification
- just prod-check
- 662 tests passed, 85% coverage
- ruff clean, pyright 0 errors
- OSV: no known vulnerabilities in 119 packages

## Hosted failure reproduced
ChatGPT rendered Unknown component undefined because the modern dispatcher used Pydantic model_dump instead of Prefab to_json, leaving child components without their type or descendants.