### PR TITLE
fix(apps): add reliable cross-client detail navigation

### DIFF
--- a/virtual-library-mcp/tests/tools/test_apps.py
+++ b/virtual-library-mcp/tests/tools/test_apps.py
@@ -139,6 +139,8 @@ class TestAppBehavior:
         assert "Book details" in payload
         assert "Library record" in payload
         assert "Check borrowing readiness" in payload
+        assert "Open The Available Book" in payload
+        assert '"action": "setState"' in payload
 
     async def test_dashboard_contains_metrics_and_popular_books(self, client):
         result = await client.call_tool(
@@ -164,6 +166,7 @@ class TestAppBehavior:
         assert "The Popular Book" in payload
         assert "Current loans" in payload
         assert "Reading profile" in payload
+        assert "Open Clean Reader" in payload
 
     async def test_checkout_readiness_resolves_book_and_patron_without_ids(self, client):
         result = await client.call_tool(
@@ -205,6 +208,7 @@ class TestAppBehavior:
         assert "patron_clean001" not in payload
         assert "clean@example.com" not in payload
         assert all(int(score) <= 100 for score in re.findall(r'"match": "(\d+)%', payload))
+        assert "Open The Available Book" in payload
 
     async def test_patron_app_explains_truncated_matches(self, client):
         result = await client.call_tool(

--- a/virtual-library-mcp/tools/apps.py
+++ b/virtual-library-mcp/tools/apps.py
@@ -127,6 +127,33 @@ def _catalog_location(genre: str) -> str:
     return "Adult Fiction"
 
 
+def _detail_buttons(
+    rows: list[dict[str, Any]],
+    *,
+    label_key: str,
+    destination: str,
+    prompt: str,
+) -> None:
+    """Add explicit drill-down controls for MCP App renderers without row events."""
+    if not rows:
+        return
+
+    with Column(gap=2):
+        Small(prompt)
+        with Grid(columns=2, gap=2):
+            for row in rows:
+                Button(
+                    f"Open {row[label_key]}",
+                    icon="arrow-right",
+                    variant="outline",
+                    size="sm",
+                    on_click=[
+                        SetState("selected", row),
+                        SetState("page", destination),
+                    ],
+                )
+
+
 def _catalog_rows(
     query: str | None,
     genre: str | None,
@@ -258,6 +285,12 @@ async def browse_catalog_app(
                         SetState("selected", Rx("$event")),
                         SetState("page", "details"),
                     ],
+                )
+                _detail_buttons(
+                    rows,
+                    label_key="title",
+                    destination="details",
+                    prompt="Open a shelf record",
                 )
 
             with Page("Book details", value="details"):
@@ -440,6 +473,12 @@ async def patron_account_app(
                             SetState("selected", Rx("$event")),
                             SetState("page", "account"),
                         ],
+                    )
+                    _detail_buttons(
+                        rows,
+                        label_key="name",
+                        destination="account",
+                        prompt="Choose an account",
                     )
                 else:
                     with Alert(variant="warning"):
@@ -858,6 +897,12 @@ async def reading_recommendations_app(
                                 SetState("selected", Rx("$event")),
                                 SetState("page", "details"),
                             ],
+                        )
+                        _detail_buttons(
+                            recommendations,
+                            label_key="title",
+                            destination="details",
+                            prompt="Open a recommendation",
                         )
                     else:
                         with Alert(variant="warning"):


### PR DESCRIPTION
## Summary
- add explicit drill-down buttons alongside DataTable row navigation
- cover catalog, patron matching, and reading recommendations
- preserve row-click behavior for clients that support it while making Claude Desktop navigation reliable
- add regression assertions for the serialized Prefab actions

## Validation
- `just prod-check`
- 662 tests passed
- ruff clean
- pyright 0 errors
- dependency audit: no known vulnerabilities
